### PR TITLE
Fixed a bug that was causing graphql_schmea command to not import properly

### DIFF
--- a/graphene_django/management/commands/graphql_schema.py
+++ b/graphene_django/management/commands/graphql_schema.py
@@ -57,8 +57,15 @@ class Command(CommandArguments):
 
     def handle(self, *args, **options):
         options_schema = options.get('schema')
-        if options_schema:
-            schema = importlib.import_module(options_schema)
+
+        if options_schema and type(options_schema) is str:
+            module_str, schema_name = options_schema.rsplit('.', 1)
+            mod = importlib.import_module(module_str)
+            schema = getattr(mod, schema_name)
+
+        elif options_schema:
+            schema = options_schema
+
         else:
             schema = graphene_settings.SCHEMA
 


### PR DESCRIPTION
There is a bug that is happening when running the graphql_schema command

AttributeError: 'Schema' object has no attribute 'startswith'

It was trying to import the schema even though it was already grabbing it with the add_arguments function