### PR TITLE
Fix ID lookup to handle cases where 'id' is not the primary key of the Django model

### DIFF
--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -98,6 +98,9 @@ class DjangoObjectTypeMeta(ObjectTypeMeta):
 
 class DjangoObjectType(six.with_metaclass(DjangoObjectTypeMeta, ObjectType)):
 
+    def resolve_id(self, args, context, info):
+        return self.pk
+
     @classmethod
     def is_type_of(cls, root, context, info):
         if isinstance(root, cls):
@@ -112,6 +115,6 @@ class DjangoObjectType(six.with_metaclass(DjangoObjectTypeMeta, ObjectType)):
     @classmethod
     def get_node(cls, id, context, info):
         try:
-            return cls._meta.model.objects.get(id=id)
+            return cls._meta.model.objects.get(pk=id)
         except cls._meta.model.DoesNotExist:
             return None


### PR DESCRIPTION
Currently, the Relay Node Interface will silently and surprisingly fail if the primary key of your Django model is not called `id`.

This addresses that by exposing the primary key (whatever it is) as the id and querying appropriately for lookups, making it easier to expose existing Django models using Graphene.