### PR TITLE
Command indent

### DIFF
--- a/examples/cookbook/cookbook/settings.py
+++ b/examples/cookbook/cookbook/settings.py
@@ -130,3 +130,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
 STATIC_URL = '/static/'
+
+GRAPHENE = {
+    'SCHEMA': 'cookbook.schema.schema',
+    'SCHEMA_INDENT': 2,
+}

--- a/graphene_django/management/commands/graphql_schema.py
+++ b/graphene_django/management/commands/graphql_schema.py
@@ -27,6 +27,13 @@ if LT_DJANGO_1_8:
                 default='',
                 help='Output file (default: schema.json)'
             ),
+            make_option(
+                '--indent',
+                type=int,
+                dest='indent',
+                default=None,
+                help='Output file indent (default: None)'
+            ),
         )
 else:
     class CommandArguments(BaseCommand):
@@ -46,14 +53,21 @@ else:
                 default=graphene_settings.SCHEMA_OUTPUT,
                 help='Output file (default: schema.json)')
 
+            parser.add_argument(
+                '--indent',
+                type=int,
+                dest='indent',
+                default=graphene_settings.SCHEMA_INDENT,
+                help='Output file indent (default: None)')
+
 
 class Command(CommandArguments):
     help = 'Dump Graphene schema JSON to file'
     can_import_settings = True
 
-    def save_file(self, out, schema_dict):
+    def save_file(self, out, schema_dict, indent):
         with open(out, 'w') as outfile:
-            json.dump(schema_dict, outfile)
+            json.dump(schema_dict, outfile, indent=indent)
 
     def handle(self, *args, **options):
         options_schema = options.get('schema')
@@ -74,8 +88,9 @@ class Command(CommandArguments):
         if not schema:
             raise CommandError('Specify schema on GRAPHENE.SCHEMA setting or by using --schema')
 
+        indent = options.get('indent')
         schema_dict = {'data': schema.introspect()}
-        self.save_file(out, schema_dict)
+        self.save_file(out, schema_dict, indent)
 
         style = getattr(self, 'style', None)
         success = getattr(style, 'SUCCESS', lambda x: x)

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -28,6 +28,7 @@ except ImportError:
 DEFAULTS = {
     'SCHEMA': None,
     'SCHEMA_OUTPUT': 'schema.json',
+    'SCHEMA_INDENT': None,
     'MIDDLEWARE': (),
 }
 


### PR DESCRIPTION
It seems to be a missing part since this command is mentioned [here](http://docs.graphene-python.org/projects/django/en/latest/introspection.html#advanced-usage).

```bash
python manage.py graphql_schema --indent 2
```
or
```python
# in settings.py
GRAPHENE = {
    'SCHEMA': 'cookbook.schema.schema',
    'SCHEMA_INDENT': 2,
}
```