### PR TITLE
Fix graphql query guide url

### DIFF
--- a/examples/cookbook/README.md
+++ b/examples/cookbook/README.md
@@ -60,5 +60,5 @@ Now you should be ready to start the server:
 Now head on over to
 [http://127.0.0.1:8000/graphql](http://127.0.0.1:8000/graphql)
 and run some queries!
-(See the [Django quickstart guide](http://graphene-python.org/docs/quickstart-django/)
+(See the [Graphene-Django Tutorial](http://docs.graphene-python.org/projects/django/en/latest/tutorial.html#testing-our-graphql-schema)
 for some example queries)


### PR DESCRIPTION
Hi,

The original path refers an unresolved url.
maybe it should be fixed...?

Thanks.