### PR TITLE
Add `pytest-runner` and test-->pytest alias to make tests run as documented

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test=pytest
+
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = django_test_settings
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ setup(
         'iso8601',
         'singledispatch>=3.4.0.3',
     ],
+    setup_requires=[
+        'pytest-runner',
+    ],
     tests_require=[
         'django-filter>=0.10.0',
         'pytest',


### PR DESCRIPTION
I recently cloned graphene-django and tried to run the tests there as documented:

`python setup.py test`

That command didn't find any test:

```
running egg_info
writing requirements to graphene_django.egg-info/requires.txt
writing graphene_django.egg-info/PKG-INFO
writing top-level names to graphene_django.egg-info/top_level.txt
writing dependency_links to graphene_django.egg-info/dependency_links.txt
reading manifest file 'graphene_django.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'graphene_django.egg-info/SOURCES.txt'
running build_ext

----------------------------------------------------------------------
Ran 0 tests in 0.000s
```


Following http://doc.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner, `pytest-runner` was added to `setup_requires` and `test` was aliased to `pytest`. Now all test run sucessfully:

```
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
django settings: django_test_settings (from ini file)
rootdir: /.../graphene-django, inifile: setup.cfg
plugins: django-2.9.1
collected 137 items 

examples/starwars/tests/test_connections.py ..
examples/starwars/tests/test_mutation.py .
examples/starwars/tests/test_objectidentification.py .....
graphene_django/debug/tests/test_query.py ....
graphene_django/filter/tests/test_fields.py ..................
graphene_django/tests/test_command.py .
graphene_django/tests/test_converter.py .................................
graphene_django/tests/test_form_converter.py ...................
graphene_django/tests/test_forms.py ....
graphene_django/tests/test_query.py ......
graphene_django/tests/test_schema.py ....
graphene_django/tests/test_types.py .....
graphene_django/tests/test_views.py ...................................

========================== 137 passed in 0.72 seconds ==========================
```