### PR TITLE
#59 fix test django settings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = django_test_settings

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [aliases]
 test=pytest
 
-[tool:pytest]
-DJANGO_SETTINGS_MODULE = django_test_settings
-
 [flake8]
 exclude = setup.py,docs/*,examples/*,tests,graphene_django/debug/sql/*
 max-line-length = 120


### PR DESCRIPTION
For some reason the [test:pytest] block wasnt working to load the DJANG_SETTINGS_MODULE this adds a pytest.ini file to hold that environment variable.