### PR TITLE
Updated Django Filter integration to 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ before_install:
 install:
 - |
   if [ "$TEST_TYPE" = build ]; then
+    pip install pytest==3.0.2 pytest-cov pytest-benchmark coveralls six pytest-django==2.9.1 mock django-filter
     pip install django==$DJANGO_VERSION
-    pip install pytest==3.0.2 pytest-cov pytest-benchmark coveralls six pytest-django==2.9.1 mock
-    pip install django==$DJANGO_FILTER_VERSION
     pip install -e .
     python setup.py develop
   elif [ "$TEST_TYPE" = lint ]; then
@@ -46,18 +45,18 @@ after_success:
   fi
 env:
   matrix:
-  - TEST_TYPE=build DJANGO_VERSION=1.10 DJANGO_FILTER_VERSION=1.0.0
+  - TEST_TYPE=build DJANGO_VERSION=1.10
 matrix:
   fast_finish: true
   include:
   - python: '2.7'
-    env: TEST_TYPE=build DJANGO_VERSION=1.6 DJANGO_FILTER_VERSION=0.15.3
+    env: TEST_TYPE=build DJANGO_VERSION=1.6
   - python: '2.7'
-    env: TEST_TYPE=build DJANGO_VERSION=1.7 DJANGO_FILTER_VERSION=0.15.3
+    env: TEST_TYPE=build DJANGO_VERSION=1.7
   - python: '2.7'
-    env: TEST_TYPE=build DJANGO_VERSION=1.8 DJANGO_FILTER_VERSION=0.15.3
+    env: TEST_TYPE=build DJANGO_VERSION=1.8
   - python: '2.7'
-    env: TEST_TYPE=build DJANGO_VERSION=1.9 DJANGO_FILTER_VERSION=1.0.0
+    env: TEST_TYPE=build DJANGO_VERSION=1.9
   - python: '2.7'
     env: TEST_TYPE=lint
 deploy:

--- a/docs/filtering.rst
+++ b/docs/filtering.rst
@@ -91,50 +91,13 @@ Which you could query as follows:
       }
     }
 
-Orderable fields
-----------------
-
-Ordering can also be specified using ``filter_order_by``. Like
-``filter_fields``, this value is also passed directly to
-``django-filter`` as the ``order_by`` field. For full details see the
-`order\_by
-documentation <https://django-filter.readthedocs.org/en/latest/usage.html#ordering-using-order-by>`__.
-
-For example:
-
-.. code:: python
-
-    class AnimalNode(DjangoObjectType):
-        class Meta:
-            model = Animal
-            filter_fields = ['name', 'genus', 'is_domesticated']
-            # Either a tuple/list of fields upon which ordering is allowed, or
-            # True to allow filtering on all fields specified in filter_fields
-            filter_order_by = True
-            interfaces = (relay.Node, )
-
-You can then control the ordering via the ``orderBy`` argument:
-
-.. code::
-
-    query {
-      allAnimals(orderBy: "name") {
-        edges {
-          node {
-            id,
-            name
-          }
-        }
-      }
-    }
-
 Custom Filtersets
 -----------------
 
 By default Graphene provides easy access to the most commonly used
 features of ``django-filter``. This is done by transparently creating a
 ``django_filters.FilterSet`` class for you and passing in the values for
-``filter_fields`` and ``filter_order_by``.
+``filter_fields``.
 
 However, you may find this to be insufficient. In these cases you can
 create your own ``Filterset`` as follows:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -98,7 +98,6 @@ Create ``cookbook/ingredients/schema.py`` and type the following:
         class Meta:
             model = Category
             filter_fields = ['name', 'ingredients']
-            filter_order_by = ['name']
             interfaces = (relay.Node, )
 
 
@@ -112,7 +111,6 @@ Create ``cookbook/ingredients/schema.py`` and type the following:
                 'category': ['exact'],
                 'category__name': ['exact'],
             }
-            filter_order_by = ['name', 'category__name']
             interfaces = (relay.Node, )
 
 

--- a/graphene_django/filter/__init__.py
+++ b/graphene_django/filter/__init__.py
@@ -8,7 +8,7 @@ if not DJANGO_FILTER_INSTALLED:
     )
 else:
     from .fields import DjangoFilterConnectionField
-    from .filterset import GrapheneFilterSet, GlobalIDFilter, GlobalIDMultipleChoiceFilter
+    from .filterset import GlobalIDFilter, GlobalIDMultipleChoiceFilter
 
-    __all__ = ['DjangoFilterConnectionField', 'GrapheneFilterSet',
+    __all__ = ['DjangoFilterConnectionField',
                'GlobalIDFilter', 'GlobalIDMultipleChoiceFilter']

--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -1,7 +1,5 @@
 from functools import partial
 
-from django_filters import OrderingFilter
-
 from ..fields import DjangoConnectionField
 from .utils import get_filtering_args_from_filterset, get_filterset_class
 

--- a/graphene_django/filter/filterset.py
+++ b/graphene_django/filter/filterset.py
@@ -1,11 +1,9 @@
 import itertools
 
-import six
-from django.conf import settings
 from django.db import models
 from django.utils.text import capfirst
 from django_filters import Filter, MultipleChoiceFilter
-from django_filters.filterset import BaseFilterSet, FilterSet, FilterSetMetaclass
+from django_filters.filterset import BaseFilterSet, FilterSet
 from django_filters.filterset import FILTER_FOR_DBFIELD_DEFAULTS
 
 from graphql_relay.node.node import from_global_id

--- a/graphene_django/filter/tests/filters.py
+++ b/graphene_django/filter/tests/filters.py
@@ -1,4 +1,5 @@
 import django_filters
+from django_filters import OrderingFilter
 
 from graphene_django.tests.models import Article, Pet, Reporter
 
@@ -12,7 +13,8 @@ class ArticleFilter(django_filters.FilterSet):
             'pub_date': ['gt', 'lt', 'exact'],
             'reporter': ['exact'],
         }
-        order_by = False
+
+    order_by = OrderingFilter(fields=('pub_date',))
 
 
 class ReporterFilter(django_filters.FilterSet):
@@ -20,7 +22,8 @@ class ReporterFilter(django_filters.FilterSet):
     class Meta:
         model = Reporter
         fields = ['first_name', 'last_name', 'email', 'pets']
-        order_by = True
+
+    order_by = OrderingFilter(fields=('pub_date',))
 
 
 class PetFilter(django_filters.FilterSet):
@@ -28,4 +31,3 @@ class PetFilter(django_filters.FilterSet):
     class Meta:
         model = Pet
         fields = ['name']
-        order_by = False

--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -11,6 +11,7 @@ from graphene_django.tests.models import Article, Pet, Reporter
 from graphene_django.utils import DJANGO_FILTER_INSTALLED
 
 pytestmark = []
+
 if DJANGO_FILTER_INSTALLED:
     import django_filters
     from graphene_django.filter import (GlobalIDFilter, DjangoFilterConnectionField,
@@ -22,28 +23,29 @@ else:
 pytestmark.append(pytest.mark.django_db)
 
 
-class ArticleNode(DjangoObjectType):
+if DJANGO_FILTER_INSTALLED:
+    class ArticleNode(DjangoObjectType):
 
-    class Meta:
-        model = Article
-        interfaces = (Node, )
-        filter_fields = ('headline', )
-
-
-class ReporterNode(DjangoObjectType):
-
-    class Meta:
-        model = Reporter
-        interfaces = (Node, )
+        class Meta:
+            model = Article
+            interfaces = (Node, )
+            filter_fields = ('headline', )
 
 
-class PetNode(DjangoObjectType):
+    class ReporterNode(DjangoObjectType):
 
-    class Meta:
-        model = Pet
-        interfaces = (Node, )
+        class Meta:
+            model = Reporter
+            interfaces = (Node, )
 
-# schema = Schema()
+
+    class PetNode(DjangoObjectType):
+
+        class Meta:
+            model = Pet
+            interfaces = (Node, )
+
+    # schema = Schema()
 
 
 def get_args(field):

--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -27,6 +27,7 @@ class ArticleNode(DjangoObjectType):
     class Meta:
         model = Article
         interfaces = (Node, )
+        filter_fields = ('headline', )
 
 
 class ReporterNode(DjangoObjectType):
@@ -110,8 +111,8 @@ def test_filter_explicit_filterset_orderable():
 
 
 def test_filter_shortcut_filterset_orderable_true():
-    field = DjangoFilterConnectionField(ReporterNode, order_by=True)
-    assert_orderable(field)
+    field = DjangoFilterConnectionField(ReporterNode)
+    assert_not_orderable(field)
 
 
 # def test_filter_shortcut_filterset_orderable_headline():
@@ -126,9 +127,9 @@ def test_filter_explicit_filterset_not_orderable():
 
 def test_filter_shortcut_filterset_extra_meta():
     field = DjangoFilterConnectionField(ArticleNode, extra_filter_meta={
-        'order_by': True
+        'exclude': ('headline', )
     })
-    assert_orderable(field)
+    assert 'headline' not in field.filterset_class.get_fields()
 
 
 def test_filter_filterset_information_on_meta():
@@ -138,11 +139,10 @@ def test_filter_filterset_information_on_meta():
             model = Reporter
             interfaces = (Node, )
             filter_fields = ['first_name', 'articles']
-            filter_order_by = True
 
     field = DjangoFilterConnectionField(ReporterFilterNode)
     assert_arguments(field, 'first_name', 'articles')
-    assert_orderable(field)
+    assert_not_orderable(field)
 
 
 def test_filter_filterset_information_on_meta_related():
@@ -152,7 +152,6 @@ def test_filter_filterset_information_on_meta_related():
             model = Reporter
             interfaces = (Node, )
             filter_fields = ['first_name', 'articles']
-            filter_order_by = True
 
     class ArticleFilterNode(DjangoObjectType):
 
@@ -160,7 +159,6 @@ def test_filter_filterset_information_on_meta_related():
             model = Article
             interfaces = (Node, )
             filter_fields = ['headline', 'reporter']
-            filter_order_by = True
 
     class Query(ObjectType):
         all_reporters = DjangoFilterConnectionField(ReporterFilterNode)
@@ -171,7 +169,7 @@ def test_filter_filterset_information_on_meta_related():
     schema = Schema(query=Query)
     articles_field = ReporterFilterNode._meta.fields['articles'].get_type()
     assert_arguments(articles_field, 'headline', 'reporter')
-    assert_orderable(articles_field)
+    assert_not_orderable(articles_field)
 
 
 def test_filter_filterset_related_results():
@@ -181,7 +179,6 @@ def test_filter_filterset_related_results():
             model = Reporter
             interfaces = (Node, )
             filter_fields = ['first_name', 'articles']
-            filter_order_by = True
 
     class ArticleFilterNode(DjangoObjectType):
 
@@ -189,7 +186,6 @@ def test_filter_filterset_related_results():
             interfaces = (Node, )
             model = Article
             filter_fields = ['headline', 'reporter']
-            filter_order_by = True
 
     class Query(ObjectType):
         all_reporters = DjangoFilterConnectionField(ReporterFilterNode)

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -18,10 +18,6 @@ def get_filtering_args_from_filterset(filterset_class, type):
         field_type.description = filter_field.label
         args[name] = field_type
 
-    # Also add the 'order_by' field
-    if getattr(filterset_class._meta, 'order_by', None):
-        args[filterset_class.order_by_field] = String()
-
     return args
 
 

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -1,7 +1,5 @@
 import six
 
-from graphene import String
-
 from .filterset import custom_filterset_factory, setup_filterset
 
 

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -65,7 +65,6 @@ class DjangoObjectTypeMeta(ObjectTypeMeta):
             # we allow more attributes in Meta
             defaults.update(
                 filter_fields=(),
-                filter_order_by=(),
             )
 
         options = Options(

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'pytest-runner',
     ],
     tests_require=[
-        'django-filter>=0.10.0',
+        'django-filter>=1.0.0',
         'pytest',
         'pytest-django==2.9.1',
         'mock',


### PR DESCRIPTION
This PR updates the integration with Django Filter, deprecating the usage of `order_by` and `filter_order_by` in Graphene Django.

The only compatible `django-filter` version will be `1.0` and above, if your project requires `django-filter` `0.1X` please use `graphene-django<="1.1"`