### PR TITLE
Fix some mistakes in documentation

### DIFF
--- a/docs/authorization.rst
+++ b/docs/authorization.rst
@@ -12,7 +12,7 @@ Let's use a simple example model.
     from django.db import models
 
     class Post(models.Model):
-        name = models.CharField(max_length=100)
+        title = models.CharField(max_length=100)
         content = models.TextField()
         published = models.BooleanField(default=False)
         owner = models.ForeignKey('auth.User')

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -31,6 +31,7 @@ We will setup the project, create the following:
 
     # Set up a new project with a single application
     django-admin.py startproject cookbook .  # Note the trailing '.' character
+    cd cookbook
     django-admin.py startapp ingredients
 
 Now sync your database for the first time:


### PR DESCRIPTION
This PR solves two mistakes in the doc :
- The `PostNode` class uses as model Post which does not have any field `title`
- The `ingredients` and `recipes` directories from [examples/cookbook](https://github.com/graphql-python/graphene-django/tree/master/examples/cookbook) are included in cookbook/cookbook. 
By following the tutorial `ingredients` and `recipes` are in `cookbook/`.

For the second problem there is two possibilities : 
1) There is a mistake in the doc and I can correct it by adding a `cd cookbook` (as done by the PR)
2) Correct the [examples/cookbook](https://github.com/graphql-python/graphene-django/tree/master/examples/cookbook).

Solution 1 is easier but I prefer the solution 2 because it is closer of what is done in the [django tutorial](https://docs.djangoproject.com/en/1.10/intro/tutorial01/). This PR implements the solution 1 but I can change if necessary.