### PR TITLE
#63 Get name of reverse_fields from model.__dict__

### DIFF
--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -33,8 +33,6 @@ def construct_fields(options):
             # Or when there is no back reference.
             continue
         converted = convert_django_field_with_choices(field, options.registry)
-        if not converted:
-            continue
         fields[name] = converted
 
     return fields

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -21,8 +21,7 @@ def construct_fields(options):
     exclude_fields = options.exclude_fields
 
     fields = OrderedDict()
-    for field in _model_fields:
-        name = field.name
+    for name, field in _model_fields:
         is_not_in_only = only_fields and name not in options.only_fields
         is_already_created = name in options.fields
         is_excluded = name in exclude_fields or is_already_created

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -30,11 +30,11 @@ def get_reverse_fields(model):
             # Hack for making it compatible with Django 1.6
             new_related = RelatedObject(related.parent_model, related.model, related.field)
             new_related.name = name
-            yield new_related
+            yield (name, new_related)
         elif isinstance(related, models.ManyToOneRel):
-            yield related
+            yield (name, related)
         elif isinstance(related, models.ManyToManyRel) and not related.symmetrical:
-            yield related
+            yield (name, related)
 
 
 def maybe_queryset(value):
@@ -45,8 +45,13 @@ def maybe_queryset(value):
 
 def get_model_fields(model):
     reverse_fields = get_reverse_fields(model)
-    all_fields = sorted(list(model._meta.fields) +
-                        list(model._meta.local_many_to_many))
+    all_fields = [
+        (field.name, field)
+        for field
+        in sorted(list(model._meta.fields) +
+                  list(model._meta.local_many_to_many))
+    ]
+
     all_fields += list(reverse_fields)
 
     return all_fields


### PR DESCRIPTION
If related name is not set, graphene-django cannot find reverse related objects. 

It is because `default_resolver` in `graphene.typemap` just get `attname` from `root`. 

Actually, the name of related objects in django model is assigned as `get_accessor_name`, not just `name` or `attname`. 

So it is needed to get name from information of `model.__dict__.items`, not `field.name`.

By modifiing like this, schema can find the corresponding related field name containing the `_set` suffix.
