### PR TITLE
Fixes filtering in nested nodes.

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -49,6 +49,7 @@ class DjangoConnectionField(ConnectionField):
             iterable = default_manager
         iterable = maybe_queryset(iterable)
         if isinstance(iterable, QuerySet):
+            iterable &= maybe_queryset(default_manager)
             _len = iterable.count()
         else:
             _len = len(iterable)

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -8,6 +8,7 @@ from py.test import raises
 import graphene
 from graphene.relay import Node
 
+from ..utils import DJANGO_FILTER_INSTALLED
 from ..compat import MissingType, RangeField
 from ..fields import DjangoConnectionField
 from ..types import DjangoObjectType
@@ -282,6 +283,9 @@ def test_should_query_connectionfields():
         }
     }
 
+
+@pytest.mark.skipif(not DJANGO_FILTER_INSTALLED,
+                    reason="django-filter should be installed")
 def test_should_query_node_filtering():
     class ReporterType(DjangoObjectType):
 
@@ -319,7 +323,6 @@ def test_should_query_node_filtering():
         editor=r,
         lang='en'
     )
-
 
     schema = graphene.Schema(query=Query)
     query = '''

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -345,25 +345,21 @@ def test_should_query_node_filtering():
     '''
 
     expected = {
-		"allReporters": {
-			"edges": [
-				{
-					"node": {
-						"id": "UmVwb3J0ZXJUeXBlOjE=", 
-						"articles": {
-							"edges": [
-								{
-									"node": {
-										"id": "QXJ0aWNsZVR5cGU6MQ=="
-									}
-								}
-							]
-						}
-					}
-				}
-			]
-		}
-	}
+        'allReporters': {
+            'edges': [{
+                'node': {
+                    'id': 'UmVwb3J0ZXJUeXBlOjE=',
+                    'articles': {
+                        'edges': [{
+                            'node': {
+                                'id': 'QXJ0aWNsZVR5cGU6MQ=='
+                            }
+                        }]
+                    }
+                }
+            }]
+        }
+    }
  
     result = schema.execute(query)
     assert not result.errors


### PR DESCRIPTION
Fixes error filtering sub-nodes. The relationships were resolved but not filtered as it was notified in issues #21 and #30.

For example:

```
query{
  allCategories {
    edges {
       node {
           id,
           ingredients(name_Icontains:"beef") {
              edges {
                 node {
                    id,
                    name
                 }
              }
           }
        }
     }
  }
}
```