### PR TITLE
Avoids collisions in choices names conversion.

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -34,7 +34,7 @@ def get_choices(choices):
                 yield choice
         else:
             name = convert_choice_name(value)
-            if name in converted_names:
+            while name in converted_names:
                 name += '_' + str(len(converted_names))
             converted_names.append(name)
             description = help_text

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -27,12 +27,16 @@ def convert_choice_name(name):
 
 
 def get_choices(choices):
+    converted_names = []
     for value, help_text in choices:
         if isinstance(help_text, (tuple, list)):
             for choice in get_choices(help_text):
                 yield choice
         else:
             name = convert_choice_name(value)
+            if name in converted_names:
+                name += '_' + str(len(converted_names))
+            converted_names.append(name)
             description = help_text
             yield name, value, description
 

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -176,6 +176,21 @@ def test_field_with_choices_gettext():
     convert_django_field_with_choices(field)
 
 
+def test_field_with_choices_collision():
+    field = models.CharField(help_text='Timezone', choices=(
+        ('Etc/GMT+1', 'Greenwich Mean Time +1'),
+        ('Etc/GMT-1', 'Greenwich Mean Time -1'),
+    ))
+
+    class CollisionChoicesModel(models.Model):
+        timezone = field
+
+        class Meta:
+            app_label = 'test'
+
+    convert_django_field_with_choices(field)
+
+
 def test_should_float_convert_float():
     assert_conversion(models.FloatField, graphene.Float)
 

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -178,6 +178,7 @@ def test_field_with_choices_gettext():
 
 def test_field_with_choices_collision():
     field = models.CharField(help_text='Timezone', choices=(
+        ('Etc/GMT+1+2', 'Fake choice to produce double collision'),
         ('Etc/GMT+1', 'Greenwich Mean Time +1'),
         ('Etc/GMT-1', 'Greenwich Mean Time -1'),
     ))


### PR DESCRIPTION
When a django field with choices is converted to an enum and the choices names are normalized, two or more names could be normalized to the same name producing a collision. For example: "Etc/GMT+1" and "Etc/GMT-1" will be converted to "ETC_GMT_1". This patch avoids collisions generating a new unique name when a collision is produced.