### PR TITLE
Return 400 status code if result has an error

### DIFF
--- a/graphene_django/tests/test_views.py
+++ b/graphene_django/tests/test_views.py
@@ -406,7 +406,7 @@ def test_supports_pretty_printing_by_request(client):
 
 def test_handles_field_errors_caught_by_graphql(client):
     response = client.get(url_string(query='{thrower}'))
-    assert response.status_code == 200
+    assert response.status_code == 400
     assert response_json(response) == {
         'data': None,
         'errors': [{'locations': [{'column': 2, 'line': 1}], 'message': 'Throws!'}]

--- a/graphene_django/tests/test_views.py
+++ b/graphene_django/tests/test_views.py
@@ -408,7 +408,6 @@ def test_handles_field_errors_caught_by_graphql(client):
     response = client.get(url_string(query='{thrower}'))
     assert response.status_code == 400
     assert response_json(response) == {
-        'data': None,
         'errors': [{'locations': [{'column': 2, 'line': 1}], 'message': 'Throws!'}]
     }
 

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -154,7 +154,7 @@ class GraphQLView(View):
             if execution_result.errors:
                 response['errors'] = [self.format_error(e) for e in execution_result.errors]
 
-            if execution_result.invalid:
+            if execution_result.invalid or execution_result.errors:
                 status_code = 400
             else:
                 response['data'] = execution_result.data


### PR DESCRIPTION
Is there any reason why we should return 200 status code on response with errors?