### PR TITLE
Allow nodes to skip the registry

### DIFF
--- a/graphene_django/registry.py
+++ b/graphene_django/registry.py
@@ -13,7 +13,8 @@ class Registry(object):
         # assert self.get_type_for_model(cls._meta.model) == cls, (
         #     'Multiple DjangoObjectTypes registered for "{}"'.format(cls._meta.model)
         # )
-        self._registry[cls._meta.model] = cls
+        if not getattr(cls._meta, 'skip_registry', False):
+            self._registry[cls._meta.model] = cls
 
     def get_type_for_model(self, model):
         return self._registry.get(model)

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -58,6 +58,7 @@ class DjangoObjectTypeMeta(ObjectTypeMeta):
             only_fields=(),
             exclude_fields=(),
             interfaces=(),
+            skip_registry=False,
             registry=None
         )
         if DJANGO_FILTER_INSTALLED:


### PR DESCRIPTION
I've added an option to nodes to skip the registry. This allows the user to control whether the node implementation of a model gets used. My use case is that I want to enable:

    class PrivateProfileNode(DjangoObjectType):
      email = graphene.Field(graphene.String)
      username = graphene.Field(graphene.String)

      class Meta:
        model = Profile
        interfaces = (graphene.relay.Node,)
        skip_registry = True


    class ProfileNode(DjangoObjectType):
      username = graphene.Field(graphene.String)

      class Meta:
        model = Profile
        interfaces = (graphene.relay.Node,)


without having to worry about the email leaking out via some other nodes.
