### PR TITLE
Avoids redundant filtering with non-nested nodes.

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -49,7 +49,8 @@ class DjangoConnectionField(ConnectionField):
             iterable = default_manager
         iterable = maybe_queryset(iterable)
         if isinstance(iterable, QuerySet):
-            iterable &= maybe_queryset(default_manager)
+            if iterable is not default_manager:
+                iterable &= maybe_queryset(default_manager)
             _len = iterable.count()
         else:
             _len = len(iterable)


### PR DESCRIPTION
Fixes an efficiency issue introduced in #82 because nested and non-nested must be filtered differently.