### PR TITLE
Remove django_graphiql from cookbook requirements.txt.

### DIFF
--- a/examples/cookbook-plain/requirements.txt
+++ b/examples/cookbook-plain/requirements.txt
@@ -1,5 +1,4 @@
 graphene
 graphene-django
-django_graphiql
 graphql-core
 django==1.9

--- a/examples/cookbook/requirements.txt
+++ b/examples/cookbook/requirements.txt
@@ -1,6 +1,5 @@
 graphene
 graphene-django
-django_graphiql
 graphql-core
 django==1.9
 django-filter==0.11.0


### PR DESCRIPTION
The package is not required since support for graphiql is now built-in.

Fixes #135.