### PR TITLE
Fix graphiql refreshing operationName undefined

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -282,6 +282,8 @@ class GraphQLView(View):
                 raise HttpError(HttpResponseBadRequest('Variables are invalid JSON.'))
 
         operation_name = request.GET.get('operationName') or data.get('operationName')
+        if operation_name == "null":
+            operation_name = None
 
         return query, variables, operation_name, id
 


### PR DESCRIPTION
operationName is serialized into the query string as a string. When getting the query value for operationName, we need to convert string "null" into None.