### PR TITLE
Fix #87: Don't create duplicate Enums for fields with choices

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -41,6 +41,10 @@ def get_choices(choices):
 
 
 def convert_django_field_with_choices(field, registry=None):
+    if registry:
+        converted = registry.get_converted_field(field)
+        if converted:
+            return converted
     choices = getattr(field, 'choices', None)
     if choices:
         meta = field.model._meta
@@ -56,8 +60,12 @@ def convert_django_field_with_choices(field, registry=None):
                 return named_choices_descriptions[self.name]
 
         enum = Enum(name, list(named_choices), type=EnumWithDescriptionsType)
-        return enum(description=field.help_text, required=not field.null)
-    return convert_django_field(field, registry)
+        converted = enum(description=field.help_text, required=not field.null)
+    else:
+        converted = convert_django_field(field, registry)
+    if registry:
+        registry.register_converted_field(field, converted)
+    return converted
 
 
 @singledispatch

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -41,7 +41,7 @@ def get_choices(choices):
 
 
 def convert_django_field_with_choices(field, registry=None):
-    if registry:
+    if registry is not None:
         converted = registry.get_converted_field(field)
         if converted:
             return converted
@@ -63,7 +63,7 @@ def convert_django_field_with_choices(field, registry=None):
         converted = enum(description=field.help_text, required=not field.null)
     else:
         converted = convert_django_field(field, registry)
-    if registry:
+    if registry is not None:
         registry.register_converted_field(field, converted)
     return converted
 

--- a/graphene_django/registry.py
+++ b/graphene_django/registry.py
@@ -2,7 +2,7 @@ class Registry(object):
 
     def __init__(self):
         self._registry = {}
-        self._registry_models = {}
+        self._field_registry = {}
 
     def register(self, cls):
         from .types import DjangoObjectType
@@ -18,6 +18,12 @@ class Registry(object):
 
     def get_type_for_model(self, model):
         return self._registry.get(model)
+
+    def register_converted_field(self, field, converted):
+        self._field_registry[field] = converted
+
+    def get_converted_field(self, field):
+        return self._field_registry.get(field)
 
 
 registry = None

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -747,3 +747,35 @@ def test_should_query_dataloader_fields():
     result = schema.execute(query)
     assert not result.errors
     assert result.data == expected
+
+
+def test_should_handle_inherited_choices():
+    class BaseModel(models.Model):
+        choice_field = models.IntegerField(choices=((0, 'zero'), (1, 'one')))
+
+    class ChildModel(BaseModel):
+        class Meta:
+            proxy = True
+
+    class BaseType(DjangoObjectType):
+        class Meta:
+            model = BaseModel
+
+    class ChildType(DjangoObjectType):
+        class Meta:
+            model = ChildModel
+
+    class Query(graphene.ObjectType):
+        base = graphene.Field(BaseType)
+        child = graphene.Field(ChildType)
+
+    schema = graphene.Schema(query=Query)
+    query = '''
+        query {
+          child {
+            choiceField
+          }
+        }
+    '''
+    result = schema.execute(query)
+    assert not result.errors


### PR DESCRIPTION
If `convert_django_field_with_choices` is called multiple times on a field with choices, a new Enum will be created each time, which breaks graphene's TypeMap. (#87)

I fixed this by storing converted Django fields in the registry, so converting the same field multiple times will return exactly the same converted object.