### PR TITLE
fix select_related and prefetch_related set in resolver getting lost

### DIFF
--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -62,7 +62,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         low = default_queryset.query.low_mark or queryset.query.low_mark
         high = default_queryset.query.high_mark or queryset.query.high_mark
         default_queryset.query.clear_limits()
-        queryset = default_queryset & queryset
+        queryset &= default_queryset
         queryset.query.set_limits(low, high)
         return queryset
 


### PR DESCRIPTION
Despite prefetching relation in resolve_ method, the relations are lost and filter redo n+1 queries.

This patch may introduce a reverse bug where relations prefetched in the default_queryset are lost, i haven't tested but i think this is way less problematic.