### PR TITLE
Fix ManyToMany schema mapping

### DIFF
--- a/graphene_django/tests/test_utils.py
+++ b/graphene_django/tests/test_utils.py
@@ -1,19 +1,5 @@
-
-
-from ..utils import get_model_fields, get_reverse_fields
+from ..utils import get_model_fields
 from .models import Film, Reporter
-
-
-def test_get_reverse_fields_correct():
-    reporter_reverse_fields = get_reverse_fields(Reporter)
-    reporter_field_names = [field[0] for field in reporter_reverse_fields]
-    assert sorted(reporter_field_names) == [
-        'articles', 'films'
-    ]
-
-    film_reverse_fields = get_reverse_fields(Film)
-    film_field_names = [field[0] for field in film_reverse_fields]
-    assert film_field_names == ['details']
 
 
 def test_get_model_fields_no_duplication():

--- a/graphene_django/tests/test_utils.py
+++ b/graphene_django/tests/test_utils.py
@@ -7,7 +7,7 @@ from .models import Film, Reporter
 def test_get_reverse_fields_correct():
     reporter_reverse_fields = get_reverse_fields(Reporter)
     reporter_field_names = [field[0] for field in reporter_reverse_fields]
-    assert reporter_field_names == [
+    assert sorted(reporter_field_names) == [
         'articles', 'films'
     ]
 

--- a/graphene_django/tests/test_utils.py
+++ b/graphene_django/tests/test_utils.py
@@ -1,0 +1,26 @@
+
+
+from ..utils import get_model_fields, get_reverse_fields
+from .models import Film, Reporter
+
+
+def test_get_reverse_fields_correct():
+    reporter_reverse_fields = get_reverse_fields(Reporter)
+    reporter_field_names = [field[0] for field in reporter_reverse_fields]
+    assert reporter_field_names == [
+        'articles', 'films'
+    ]
+
+    film_reverse_fields = get_reverse_fields(Film)
+    film_field_names = [field[0] for field in film_reverse_fields]
+    assert film_field_names == ['details']
+
+
+def test_get_model_fields_no_duplication():
+    reporter_fields = get_model_fields(Reporter)
+    reporter_name_set = set([field[0] for field in reporter_fields])
+    assert len(reporter_fields) == len(reporter_name_set)
+
+    film_fields = get_model_fields(Film)
+    film_name_set = set([field[0] for field in film_fields])
+    assert len(film_fields) == len(film_name_set)

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -33,7 +33,7 @@ def get_reverse_fields(model):
             yield (name, new_related)
         elif isinstance(related, models.ManyToOneRel):
             yield (name, related)
-        elif isinstance(related, models.ManyToManyRel) and not related.symmetrical:
+        elif isinstance(related, models.ManyToManyRel) and attr.reverse and not related.symmetrical:
             yield (name, related)
 
 

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -33,7 +33,7 @@ def get_reverse_fields(model):
             yield (name, new_related)
         elif isinstance(related, models.ManyToOneRel):
             yield (name, related)
-        elif isinstance(related, models.ManyToManyRel) and attr.reverse and not related.symmetrical:
+        elif isinstance(related, models.ManyToManyRel) and not related.symmetrical:
             yield (name, related)
 
 
@@ -52,7 +52,14 @@ def get_model_fields(model):
                   list(model._meta.local_many_to_many))
     ]
 
-    all_fields += list(reverse_fields)
+    # Make sure we don't duplicate local fields with "reverse" version
+    all_field_names = [field[0] for field in all_fields]
+    actual_reverse_fields = [
+        reverse_field for reverse_field in reverse_fields
+        if reverse_field[0] not in all_field_names
+    ]
+
+    all_fields += list(actual_reverse_fields)
 
     return all_fields
 


### PR DESCRIPTION
Issues
closes #155 
closes #157 
closes #172

### The Problem

ManyToMany fields were not mapping correctly and required some less than ideal workarounds.

This was because the `get_reverse_fields` did not differentiate between the original instantiation of the `ManyToMany` and the automatic `reverse` version. There was then two copies of the field coming back from `get_model_fields`, the one at the end being incorrect.

### The Solution

Unfortunately, the `reverse` flag on the "reverse" fields has not always been around. To maintain backwards compatibility, `get_reverse_fields` is doing the best it can.

Instead, we can make sure that local fields are not overridden by reverse fields. So a few lines in `get_model_fields` limits `get_reverse_fields` to skip local fields.

### Tests
Before fix:
<img width="1136" alt="screen shot 2017-05-25 at 11 25 09 am" src="https://cloud.githubusercontent.com/assets/1591840/26459736/13a195da-413d-11e7-8245-201ac7fdcce7.png">


After fix:
<img width="1136" alt="screen shot 2017-05-25 at 11 26 01 am" src="https://cloud.githubusercontent.com/assets/1591840/26459745/1b7308e8-413d-11e7-9b2c-095a6c9f8946.png">

### Example
Before fix:
<img width="308" alt="screen shot 2017-05-25 at 11 34 12 am" src="https://cloud.githubusercontent.com/assets/1591840/26460351/036e2bc2-413f-11e7-9950-3cc713f187c0.png">

After fix:
<img width="328" alt="screen shot 2017-05-25 at 11 40 30 am" src="https://cloud.githubusercontent.com/assets/1591840/26460359/0b8ad454-413f-11e7-9559-4ca4b8870ced.png">



