### PR TITLE
Support formatting of enum choices

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -1,3 +1,5 @@
+import enum
+
 from django.db import models
 from django.utils.encoding import force_text
 
@@ -17,6 +19,8 @@ singledispatch = import_single_dispatch()
 
 
 def convert_choice_name(name):
+    if isinstance(name, enum.Enum):
+        name = name.name
     name = to_const(force_text(name))
     try:
         assert_valid_name(name)


### PR DESCRIPTION
When using [django_enumfields](https://github.com/hzdg/django-enumfields) ```field.choices``` is a list of the enum 'constants' and their labels / names. ```convert_choice_name``` renders the 'values' with str. This ok for normal choice values, but the string representation of python ```Enum```s follows the TypeName.VALUE format. This results in TYPENAME_VALUE formatted values for GraphQL queries, instead of VALUE (which I think it should be). This PR fixes that.