### PR TITLE
Inheritance support for GraphQLView (class attributes)

### DIFF
--- a/graphene_django/tests/test_views.py
+++ b/graphene_django/tests/test_views.py
@@ -386,6 +386,24 @@ def test_allows_post_with_get_operation_name(client):
     }
 
 
+@pytest.mark.urls('graphene_django.tests.urls_inherited')
+def test_inherited_class_with_attributes_works(client):
+    inherited_url = '/graphql/inherited/'
+    # Check schema and pretty attributes work
+    response = client.post(url_string(inherited_url, query='{test}'))
+    assert response.content.decode() == (
+        '{\n'
+        '  "data": {\n'
+        '    "test": "Hello World"\n'
+        '  }\n'
+        '}'
+    )
+
+    # Check graphiql works
+    response = client.get(url_string(inherited_url), HTTP_ACCEPT='text/html')
+    assert response.status_code == 200
+
+
 @pytest.mark.urls('graphene_django.tests.urls_pretty')
 def test_supports_pretty_printing(client):
     response = client.get(url_string(query='{test}'))

--- a/graphene_django/tests/urls_inherited.py
+++ b/graphene_django/tests/urls_inherited.py
@@ -1,0 +1,14 @@
+from django.conf.urls import url
+
+from ..views import GraphQLView
+from .schema_view import schema
+
+class CustomGraphQLView(GraphQLView):
+    schema = schema
+    graphiql = True
+    pretty = True
+
+
+urlpatterns = [
+    url(r'^graphql/inherited/$', CustomGraphQLView.as_view()),
+]

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -72,14 +72,14 @@ class GraphQLView(View):
         if middleware is None:
             middleware = graphene_settings.MIDDLEWARE
 
-        self.schema = schema
+        self.schema = self.schema or schema
         if middleware is not None:
             self.middleware = list(instantiate_middleware(middleware))
         self.executor = executor
         self.root_value = root_value
-        self.pretty = pretty
-        self.graphiql = graphiql
-        self.batch = batch
+        self.pretty = self.pretty or pretty
+        self.graphiql = self.graphiql or graphiql
+        self.batch = self.batch or batch
 
         assert isinstance(
             self.schema, GraphQLSchema), 'A Schema is required to be provided to GraphQLView.'


### PR DESCRIPTION
Proposal for solving #211 (closes #211)

schema, pretty, graphiql and batch attributes can be defined in style of CBV

```python
class MyGraphQLView(GraphQLView):
    graphiql = True
    schema = SomeSchema
    pretty = True
    batch = True  # Of course cannot define both batch and graphiql, just an example
```
There is also simple test for all attributes except batch (because all 4 implemented in the same style).