### PR TITLE
Adding select_related and prefetch_related optimizations

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -24,7 +24,12 @@ class DjangoListField(Field):
 
     @staticmethod
     def list_resolver(resolver, root, args, context, info):
-        return maybe_queryset(resolver(root, args, context, info))
+        qs = maybe_queryset(resolver(root, args, context, info))
+
+        if isinstance(qs, QuerySet):
+            qs = optimize_queryset(qs.model, qs, info.field_asts[0])
+
+        return qs
 
     def get_resolver(self, parent_resolver):
         return partial(self.list_resolver, parent_resolver)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -27,7 +27,7 @@ class DjangoListField(Field):
         qs = maybe_queryset(resolver(root, args, context, info))
 
         if isinstance(qs, QuerySet):
-            qs = optimize_queryset(qs.model, qs, info.field_asts[0])
+            qs = optimize_queryset(qs, info.field_asts[0])
 
         return qs
 
@@ -76,7 +76,7 @@ class DjangoConnectionField(ConnectionField):
             if iterable is not default_manager:
                 default_queryset = maybe_queryset(default_manager)
                 iterable = cls.merge_querysets(default_queryset, iterable)
-            iterable = optimize_queryset(default_manager.model, iterable, info.field_asts[0])
+            iterable = optimize_queryset(iterable, info.field_asts[0])
             _len = iterable.count()
         else:
             _len = len(iterable)

--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -76,7 +76,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
             data=filter_kwargs,
             queryset=default_manager.get_queryset()
         ).qs
-        qs = optimize_queryset(default_manager.model, qs, info.field_asts[0])
+        qs = optimize_queryset(qs, info.field_asts[0])
 
         return super(DjangoFilterConnectionField, cls).connection_resolver(
             resolver,

--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -4,6 +4,7 @@ from functools import partial
 # from graphene.relay import is_node
 from graphene.types.argument import to_arguments
 from ..fields import DjangoConnectionField
+from ..optimization import optimize_queryset
 from .utils import get_filtering_args_from_filterset, get_filterset_class
 
 
@@ -75,6 +76,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
             data=filter_kwargs,
             queryset=default_manager.get_queryset()
         ).qs
+        qs = optimize_queryset(default_manager.model, qs, info.field_asts[0])
 
         return super(DjangoFilterConnectionField, cls).connection_resolver(
             resolver,

--- a/graphene_django/optimization.py
+++ b/graphene_django/optimization.py
@@ -82,8 +82,8 @@ def get_related_fetches_for_model(model, graphql_ast):
     return relateds
 
 
-def optimize_queryset(model, queryset, graphql_ast):
-    relateds = get_related_fetches_for_model(model, graphql_ast)
+def optimize_queryset(queryset, graphql_ast):
+    relateds = get_related_fetches_for_model(queryset.model, graphql_ast)
 
     for related in relateds:
         if related.fetch_type == SELECT:

--- a/graphene_django/optimization.py
+++ b/graphene_django/optimization.py
@@ -1,0 +1,82 @@
+from collections import namedtuple
+
+from django.db.models import ForeignKey
+from django.db.models.fields.reverse_related import ForeignObjectRel
+from graphene.utils.str_converters import to_snake_case
+
+from .registry import get_global_registry
+from .utils import get_related_model
+
+REGISTRY = get_global_registry()
+SELECT = 'select'
+PREFETCH = 'prefetch'
+RelatedSelection = namedtuple('RelatedSelection', ['name', 'fetch_type'])
+
+
+def model_fields_as_dict(model):
+    return dict((f.name, f) for f in model._meta.get_fields())
+
+
+def get_related_fetches_for_model(model, graphql_ast):
+    model_fields = model_fields_as_dict(model)
+    selections = graphql_ast.selection_set.selections
+
+    graphene_obj_type = REGISTRY.get_type_for_model(model)
+    optimizations = {}
+    if graphene_obj_type and graphene_obj_type._meta.optimizations:
+        optimizations = graphene_obj_type._meta.optimizations
+
+    relateds = []
+
+    for selection in selections:
+        selection_name = to_snake_case(selection.name.value)
+        selection_field = model_fields.get(selection_name, None)
+
+        try:
+            related_model = get_related_model(selection_field)
+        except:
+            # This is not a ForeignKey or Relation, check manual optimizations
+            manual_optimizations = optimizations.get(selection_name)
+            if manual_optimizations:
+                for manual_select in manual_optimizations.get(SELECT, []):
+                    relateds.append(RelatedSelection(manual_select, SELECT))
+                for manual_prefetch in manual_optimizations.get(PREFETCH, []):
+                    relateds.append(RelatedSelection(manual_prefetch, PREFETCH))
+
+            continue
+
+        query_name = selection_field.name
+        if isinstance(selection_field, ForeignObjectRel):
+            query_name = selection_field.field.related_query_name()
+
+        nested_relateds = get_related_fetches_for_model(related_model, selection)
+
+        related_type = PREFETCH  # default to prefetch, it's safer
+        if isinstance(selection_field, ForeignKey):
+            related_type = SELECT  # we can only select for ForeignKeys
+
+        if nested_relateds:
+            for related in nested_relateds:
+                full_name = '{0}__{1}'.format(query_name, related.name)
+
+                nested_related_type = PREFETCH
+                if related_type == SELECT and related.fetch_type == SELECT:
+                    nested_related_type = related_type
+
+                relateds.append(RelatedSelection(full_name, nested_related_type))
+        else:
+            relateds.append(RelatedSelection(query_name, related_type))
+
+    return relateds
+
+
+def optimize_queryset(model, queryset, graphql_ast):
+    relateds = get_related_fetches_for_model(model, graphql_ast)
+
+    for related in relateds:
+        if related.fetch_type == SELECT:
+            queryset = queryset.select_related(related.name)
+        else:
+            queryset = queryset.prefetch_related(related.name)
+
+    return queryset

--- a/graphene_django/optimization.py
+++ b/graphene_django/optimization.py
@@ -17,9 +17,21 @@ def model_fields_as_dict(model):
     return dict((f.name, f) for f in model._meta.get_fields())
 
 
+def find_model_selections(ast):
+    selections = ast.selection_set.selections
+
+    for selection in selections:
+        if selection.name.value == 'edges':
+            for sub_selection in selection.selection_set.selections:
+                if sub_selection.name.value == 'node':
+                    return sub_selection.selection_set.selections
+
+    return selections
+
+
 def get_related_fetches_for_model(model, graphql_ast):
     model_fields = model_fields_as_dict(model)
-    selections = graphql_ast.selection_set.selections
+    selections = find_model_selections(graphql_ast)
 
     graphene_obj_type = REGISTRY.get_type_for_model(model)
     optimizations = {}

--- a/graphene_django/tests/test_optimization.py
+++ b/graphene_django/tests/test_optimization.py
@@ -1,0 +1,126 @@
+from datetime import date
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+import graphene
+import pytest
+
+from .. import registry
+from ..fields import DjangoConnectionField
+from ..optimization import optimize_queryset
+from ..types import DjangoObjectType
+from .models import (
+    Article as ArticleModel,
+    Reporter as ReporterModel,
+    Pet as PetModel
+)
+
+pytestmark = pytest.mark.django_db
+
+registry.reset_global_registry()
+
+
+class Article(DjangoObjectType):
+    class Meta:
+        model = ArticleModel
+        interfaces = (graphene.relay.Node,)
+
+
+class Reporter(DjangoObjectType):
+    class Meta:
+        model = ReporterModel
+
+
+class Pet(DjangoObjectType):
+    class Meta:
+        model = PetModel
+
+
+class RootQuery(graphene.ObjectType):
+    article = graphene.Field(Article, id=graphene.ID())
+    articles = DjangoConnectionField(Article)
+
+    def resolve_article(self, args, context, info):
+        qs = ArticleModel.objects
+        qs = optimize_queryset(ArticleModel, qs, info.field_asts[0])
+        return qs.get(**args)
+
+
+schema = graphene.Schema(query=RootQuery)
+
+
+class TestOptimization(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.reporter = ReporterModel.objects.create(
+            first_name='Clark', last_name='Kent',
+            email='ckent@dailyplanet.com', a_choice='this'
+        )
+        cls.editor = ReporterModel.objects.create(
+            first_name='Perry', last_name='White',
+            email='pwhite@dailyplanet.com', a_choice='this'
+        )
+        cls.article = ArticleModel.objects.create(
+            headline='Superman Saves the Day',
+            pub_date=date.today(),
+            reporter=cls.reporter,
+            editor=cls.editor
+        )
+        cls.other_article = ArticleModel.objects.create(
+            headline='Lex Luthor is SO Rich',
+            pub_date=date.today(),
+            reporter=cls.reporter,
+            editor=cls.editor
+        )
+        cls.editor.pets.add(cls.reporter)
+
+    def test_select_related(self):
+        query = """query GetArticle($articleId: ID!){
+          article(id: $articleId) {
+              headline
+              reporter {
+                email
+              }
+              editor {
+                email
+              }
+          }
+        }"""
+
+        variables = {'articleId': str(self.article.id)}
+
+        with CaptureQueriesContext(connection) as query_context:
+            results = schema.execute(query, variable_values=variables)
+
+        returned_article = results.data['article']
+        assert returned_article['headline'] == self.article.headline
+        assert returned_article['reporter']['email'] == self.reporter.email
+        assert returned_article['editor']['email'] == self.editor.email
+
+        self.assertEqual(len(query_context.captured_queries), 1)
+
+    def test_prefetch_related(self):
+        query = """query {
+          articles {
+            edges {
+              node {
+                headline
+                editor {
+                  email
+                  pets {
+                    email
+                  }
+                }
+              }
+            }
+          }
+        }"""
+
+        with CaptureQueriesContext(connection) as query_context:
+            results = schema.execute(query)
+
+        returned_articles = results.data['articles']['edges']
+        assert len(returned_articles) == 2
+
+        self.assertEqual(len(query_context.captured_queries), 4)

--- a/graphene_django/tests/test_optimization.py
+++ b/graphene_django/tests/test_optimization.py
@@ -44,7 +44,7 @@ class RootQuery(graphene.ObjectType):
 
     def resolve_article(self, args, context, info):
         qs = ArticleModel.objects
-        qs = optimize_queryset(ArticleModel, qs, info.field_asts[0])
+        qs = optimize_queryset(qs, info.field_asts[0])
         return qs.get(**args)
 
     def resolve_reporters(self, args, context, info):

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -1,4 +1,4 @@
-from mock import patch
+from mock import Mock, patch
 
 from graphene import Interface, ObjectType, Schema
 from graphene.relay import Node
@@ -38,7 +38,11 @@ def test_django_interface():
 
 @patch('graphene_django.tests.models.Article.objects.get', return_value=Article(id=1))
 def test_django_get_node(get):
-    article = Article.get_node(1, None, None)
+    ast_mock = Mock()
+    ast_mock.selection_set.selections = []
+    info_mock = Mock(field_asts=[ast_mock])
+
+    article = Article.get_node(1, None, info_mock)
     get.assert_called_with(pk=1)
     assert article.id == 1
 

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -10,6 +10,7 @@ from graphene.types.utils import merge, yank_fields_from_attrs
 from graphene.utils.is_base_type import is_base_type
 
 from .converter import convert_django_field_with_choices
+from .optimization import optimize_queryset
 from .registry import Registry, get_global_registry
 from .utils import (DJANGO_FILTER_INSTALLED, get_model_fields,
                     is_valid_django_model)
@@ -55,6 +56,7 @@ class DjangoObjectTypeMeta(ObjectTypeMeta):
             only_fields=(),
             exclude_fields=(),
             interfaces=(),
+            optimizations=None,
             skip_registry=False,
             registry=None
         )
@@ -118,7 +120,9 @@ class DjangoObjectType(six.with_metaclass(DjangoObjectTypeMeta, ObjectType)):
 
     @classmethod
     def get_node(cls, id, context, info):
+        query = cls._meta.model._meta.default_manager
+        query = optimize_queryset(cls._meta.model, query, info.field_asts[0])
         try:
-            return cls._meta.model.objects.get(pk=id)
+            return query.get(pk=id)
         except cls._meta.model.DoesNotExist:
             return None

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -121,7 +121,7 @@ class DjangoObjectType(six.with_metaclass(DjangoObjectTypeMeta, ObjectType)):
     @classmethod
     def get_node(cls, id, context, info):
         query = cls._meta.model._meta.default_manager
-        query = optimize_queryset(cls._meta.model, query, info.field_asts[0])
+        query = optimize_queryset(query, info.field_asts[0])
         try:
             return query.get(pk=id)
         except cls._meta.model.DoesNotExist:


### PR DESCRIPTION
Using a combination of Model meta and the graphql AST, we are able to use django's `queryset.select_related()` and `queryset.prefetch_related()` to reduce the number of queries run during a graphql query resolution.

These optimizations help a lot with the N+1 problem faced when using an ORM.

I have written the primary entry point (`optimizations.optimize_queryset`) such that it can be imported and used in any graphql resolution function. (See `resolve_article` in the tests). I then used it in several core places, including `DjangoConnectionField`, `DjangoListField`, and `DjangoObjectType`.

There will always be cases when the graphql representation does not match the model meta, either an alias or perhaps a complicated model `@property`. In those cases, you can specify manual optimizations in the `DjangoObjectType` Meta. Those optimizations look like:

```python
class MyObject(DjangoObjectType):
    special_property = graphene.SomeField()

    class Meta:
        model = MyObjectModel
        optimizations = {
            'special_property': {
                'prefetch': ['relations__to__prefetch'],
                'select': ['relation__to__select']
            }
        }
```

Closes #57