### PR TITLE
Fix select_related with filtering

### DIFF
--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -43,8 +43,8 @@ class DjangoFilterConnectionField(DjangoConnectionField):
     def filtering_args(self):
         return get_filtering_args_from_filterset(self.filterset_class, self.node_type)
 
-    @staticmethod
-    def merge_querysets(default_queryset, queryset):
+    @classmethod
+    def merge_querysets(cls, default_queryset, queryset):
         # There could be the case where the default queryset (returned from the filterclass)
         # and the resolver queryset have some limits on it.
         # We only would be able to apply one of those, but not both
@@ -61,7 +61,9 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         low = default_queryset.query.low_mark or queryset.query.low_mark
         high = default_queryset.query.high_mark or queryset.query.high_mark
         default_queryset.query.clear_limits()
-        queryset = queryset & default_queryset
+
+        queryset = super(cls, cls).merge_querysets(default_queryset, queryset)
+
         queryset.query.set_limits(low, high)
         return queryset
 

--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -61,7 +61,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         low = default_queryset.query.low_mark or queryset.query.low_mark
         high = default_queryset.query.high_mark or queryset.query.high_mark
         default_queryset.query.clear_limits()
-        queryset = default_queryset & queryset
+        queryset = queryset & default_queryset
         queryset.query.set_limits(low, high)
         return queryset
 


### PR DESCRIPTION
I must admit, I don't totally see the need for this union between the ``default_queryset`` and ``queryset`` but through experimentation, I have found that if the order of the union is reversed, it will preserve the ``select_related`` and ``prefetch_related``.  It has the same effect of finding the union of records returned.  The list is identical.

So I hope this change doesn't break something I'm not aware of.  :)

This is an attempt to fix https://github.com/graphql-python/graphene-django/issues/179