### PR TITLE
Remove usages of deprecated field.rel

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -11,7 +11,7 @@ from graphql import assert_valid_name
 
 from .compat import ArrayField, HStoreField, JSONField, RangeField
 from .fields import get_connection_field, DjangoListField
-from .utils import get_related_model, import_single_dispatch
+from .utils import import_single_dispatch
 
 singledispatch = import_single_dispatch()
 
@@ -122,7 +122,7 @@ def convert_time_to_string(field, registry=None):
 
 @convert_django_field.register(models.OneToOneRel)
 def convert_onetoone_field_to_djangomodel(field, registry=None):
-    model = get_related_model(field)
+    model = field.related_model
 
     def dynamic_type():
         _type = registry.get_type_for_model(model)
@@ -141,7 +141,7 @@ def convert_onetoone_field_to_djangomodel(field, registry=None):
 @convert_django_field.register(models.ManyToManyRel)
 @convert_django_field.register(models.ManyToOneRel)
 def convert_field_to_list_or_connection(field, registry=None):
-    model = get_related_model(field)
+    model = field.related_model
 
     def dynamic_type():
         _type = registry.get_type_for_model(model)
@@ -159,7 +159,7 @@ def convert_field_to_list_or_connection(field, registry=None):
 @convert_django_field.register(models.OneToOneField)
 @convert_django_field.register(models.ForeignKey)
 def convert_field_to_djangomodel(field, registry=None):
-    model = get_related_model(field)
+    model = field.related_model
 
     def dynamic_type():
         _type = registry.get_type_for_model(model)

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -56,13 +56,6 @@ def get_model_fields(model):
     return all_fields
 
 
-def get_related_model(field):
-    if hasattr(field, 'rel'):
-        # Django 1.6, 1.7
-        return field.rel.to
-    return field.related_model
-
-
 def is_valid_django_model(model):
     return inspect.isclass(model) and issubclass(model, models.Model)
 


### PR DESCRIPTION
Since they were only required for Django <1.8 and cause the following deprecation warnings:

```
utils.py:61: RemovedInDjango20Warning: Usage of field.rel has been deprecated. Use field.remote_field instead.
    if hasattr(field, 'rel'):
utils.py:63: RemovedInDjango20Warning: Usage of ForeignObjectRel.to attribute has been deprecated. Use the model attribute instead.
    return field.rel.to
```

Fixes #242.