### PR TITLE
fix various SerializerMutation regressions

### DIFF
--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -55,6 +55,7 @@ class SerializerMutation(ClientIDMutation):
         output_fields = fields_for_serializer(serializer, only_fields, exclude_fields, is_input=False)
 
         _meta = SerializerMutationOptions(cls)
+        _meta.serializer_class = serializer_class
         _meta.fields = yank_fields_from_attrs(
             output_fields,
             _as=Field,

--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -84,4 +84,4 @@ class SerializerMutation(ClientIDMutation):
     @classmethod
     def perform_mutate(cls, serializer, info):
         obj = serializer.save()
-        return cls(**obj)
+        return cls(errors=None, **obj)

--- a/graphene_django/rest_framework/tests/test_mutation.py
+++ b/graphene_django/rest_framework/tests/test_mutation.py
@@ -65,7 +65,6 @@ def test_nested_model():
     assert model_field.type == MyFakeModelGrapheneType
 
     model_input = MyMutation.Input._meta.fields['model']
-    model_input_type = model_input.get_type()
-    assert not model_input_type
-    # assert issubclass(model_input_type, InputObjectType)
-    # assert 'cool_name' in model_input_type._meta.fields
+    model_input_type = model_input._type.of_type
+    assert issubclass(model_input_type, InputObjectType)
+    assert 'cool_name' in model_input_type._meta.fields

--- a/graphene_django/rest_framework/tests/test_mutation.py
+++ b/graphene_django/rest_framework/tests/test_mutation.py
@@ -22,6 +22,9 @@ class MySerializer(serializers.Serializer):
     text = serializers.CharField()
     model = MyModelSerializer()
 
+    def create(self, validated_data):
+        return validated_data
+
 
 def test_needs_serializer_class():
     with raises(Exception) as exc:
@@ -68,3 +71,29 @@ def test_nested_model():
     model_input_type = model_input._type.of_type
     assert issubclass(model_input_type, InputObjectType)
     assert 'cool_name' in model_input_type._meta.fields
+
+
+def test_mutate_and_get_payload_success():
+
+    class MyMutation(SerializerMutation):
+        class Meta:
+            serializer_class = MySerializer
+
+    result = MyMutation.mutate_and_get_payload(None, None, **{
+        'text': 'value',
+        'model': {
+            'cool_name': 'other_value'
+        }
+    })
+    assert result.errors is None
+
+
+def test_mutate_and_get_payload_error():
+
+    class MyMutation(SerializerMutation):
+        class Meta:
+            serializer_class = MySerializer
+
+    # missing required fields
+    result = MyMutation.mutate_and_get_payload(None, None, **{})
+    assert len(result.errors) > 0


### PR DESCRIPTION
Following the 2.x work SerializerMutation is no longer working for me. I think I found 3 issues:

* Support for input fields was removed in 72529b7 causing SerializerMutations to accept only clientMutationId as input
* _meta.serializer_class is no longer set causing mutate_and_get_payload to throw a NoneType not callable error
* On success SerializerMutation.errors is graphene.List rather than None, leading to an error because graphene.List is not a valid value for a list

Thanks for looking

Fixes #259