### PR TITLE
Pass context to serializer so authentication works

### DIFF
--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -69,7 +69,7 @@ class SerializerMutation(ClientIDMutation):
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
-        serializer = cls._meta.serializer_class(data=input, context=info.context)
+        serializer = cls._meta.serializer_class(data=input, context=getattr(info, 'context', None))
 
         if serializer.is_valid():
             return cls.perform_mutate(serializer, info)

--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -69,7 +69,7 @@ class SerializerMutation(ClientIDMutation):
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
-        serializer = cls._meta.serializer_class(data=input)
+        serializer = cls._meta.serializer_class(data=input, context=info.context)
 
         if serializer.is_valid():
             return cls.perform_mutate(serializer, info)


### PR DESCRIPTION
Without passing the context when creating the serializer you can't access the user in validation. Simply add the context when creating the serializer class fixes the authentication.