### PR TITLE
Fix failing master test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ install:
     pip install -e .[test]
     pip install psycopg2 # Required for Django postgres fields testing
     pip install django==$DJANGO_VERSION
+    if [ $DJANGO_VERSION = 1.8 ]; then # DRF dropped 1.8 support at 3.7.0
+      pip install djangorestframework==3.6.4
+    fi
     python setup.py develop
   elif [ "$TEST_TYPE" = lint ]; then
     pip install flake8

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('graphene_django/__init__.py', 'rb') as f:
         f.read().decode('utf-8')).group(1)))
 
 rest_framework_require = [
-    'djangorestframework>=3.6.3,<3.7.0',
+    'djangorestframework>=3.6.3',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('graphene_django/__init__.py', 'rb') as f:
         f.read().decode('utf-8')).group(1)))
 
 rest_framework_require = [
-    'djangorestframework>=3.6.3',
+    'djangorestframework>=3.6.3,<3.7.0',
 ]
 
 


### PR DESCRIPTION
### Problem
Master tests started failing in a strange way.

See https://travis-ci.org/graphql-python/graphene-django/jobs/285520455

It is only failing for the Django 1.8 build. It took a while to pinpoint *why*, as nothing in our repository changed related to the failure.

https://github.com/encode/django-rest-framework/commit/c674687782ef96a3bb8466b412e99debd3d04f00

Is what started the failure. DRF 3.7.0 does not support Django 1.8 anymore.

### Solution
For now, I have a conditional pip install override for our 1.8 build. A few other options exist as well.

* We could follow suit and stop supporting 1.8.
* We could pin the general requirement in setup.py to be <3.7.0.
* Maybe something else?