### PR TITLE
Use maybe_queryset in DjangoFilterConnectionField

### DIFF
--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -2,7 +2,9 @@ from collections import OrderedDict
 from functools import partial
 
 from graphene.types.argument import to_arguments
+
 from ..fields import DjangoConnectionField
+from ..utils import maybe_queryset
 from .utils import get_filtering_args_from_filterset, get_filterset_class
 
 
@@ -72,7 +74,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         filter_kwargs = {k: v for k, v in args.items() if k in filtering_args}
         qs = filterset_class(
             data=filter_kwargs,
-            queryset=default_manager.get_queryset()
+            queryset=maybe_queryset(default_manager)
         ).qs
 
         return super(DjangoFilterConnectionField, cls).connection_resolver(


### PR DESCRIPTION
In our projects we've found a need to inherit from
DjangoFilterConnectionField in order to customize the queryset. When
passing the queryset into "connection_resolver", an error was
raised about "get_queryset" not existing. This is due to the
assumption that the "base_manager" is always a manager. Using
"maybe_queryset" resolves the issue.

If there's a better way of doing any of this please let me know.