### PR TITLE
typo in authorization.rst

### DIFF
--- a/docs/authorization.rst
+++ b/docs/authorization.rst
@@ -34,7 +34,7 @@ This is easy, simply use the ``only_fields`` meta attribute.
             only_fields = ('title', 'content')
             interfaces = (relay.Node, )
 
-conversely you can use ``exclude_fields`` meta atrribute.
+conversely you can use ``exclude_fields`` meta attribute.
 
 .. code:: python
 


### PR DESCRIPTION
fix a small typo error in the documentation