### PR TITLE
Allow DjangoObjectType to use an Abstract Connection Class

### DIFF
--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -1,6 +1,6 @@
 from mock import patch
 
-from graphene import Interface, ObjectType, Schema
+from graphene import Interface, ObjectType, Schema, Connection, String
 from graphene.relay import Node
 
 from .. import registry
@@ -17,11 +17,23 @@ class Reporter(DjangoObjectType):
         model = ReporterModel
 
 
+class ArticleConnection(Connection):
+    '''Article Connection'''
+    test = String()
+
+    def resolve_test():
+        return 'test'
+
+    class Meta:
+        abstract = True
+
+
 class Article(DjangoObjectType):
     '''Article description'''
     class Meta:
         model = ArticleModel
         interfaces = (Node, )
+        connection_class = ArticleConnection
 
 
 class RootQuery(ObjectType):
@@ -74,6 +86,7 @@ type Article implements Node {
 type ArticleConnection {
   pageInfo: PageInfo!
   edges: [ArticleEdge]!
+  test: String
 }
 
 type ArticleEdge {

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -45,7 +45,7 @@ class DjangoObjectType(ObjectType):
     @classmethod
     def __init_subclass_with_meta__(cls, model=None, registry=None, skip_registry=False,
                                     only_fields=(), exclude_fields=(), filter_fields=None, connection=None,
-                                    use_connection=None, interfaces=(), **options):
+                                    connection_class=None, use_connection=None, interfaces=(), **options):
         assert is_valid_django_model(model), (
             'You need to pass a valid Django Model in {}.Meta, received "{}".'
         ).format(cls.__name__, model)
@@ -71,7 +71,11 @@ class DjangoObjectType(ObjectType):
 
         if use_connection and not connection:
             # We create the connection automatically
-            connection = Connection.create_type('{}Connection'.format(cls.__name__), node=cls)
+            if not connection_class:
+                connection_class = Connection
+
+            connection = connection_class.create_type(
+                '{}Connection'.format(cls.__name__), node=cls)
 
         if connection is not None:
             assert issubclass(connection, Connection), (


### PR DESCRIPTION
referred to as connection_class, it will instantiate the connection from the provided class or default to graphene.Connection if not supplied

Solves #304

I created this second pull request to merge from a branch of my fork so that I can keep making changes without them being merged into this pr