### PR TITLE
Fix Bug causing DjangoFilterConnectionField to ignore annotations, .reverse()

### DIFF
--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -61,7 +61,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         low = default_queryset.query.low_mark or queryset.query.low_mark
         high = default_queryset.query.high_mark or queryset.query.high_mark
         default_queryset.query.clear_limits()
-        queryset = default_queryset & queryset
+        queryset = queryset & default_queryset
         queryset.query.set_limits(low, high)
         return queryset
 


### PR DESCRIPTION
other queryset modifications being applied in resolvers.

the actual fix is really small. 

In  ```DjangoFilterConnectionField.merge_querysets```  default_queryset was overriding queryset.

if you look at ```DjangoConnectionField.merge_querysets``` you can see it was doing this merge correctly. 

```python
@classmethod
    def merge_querysets(cls, default_queryset, queryset):
        return queryset & default_queryset 
```

So this pr simply changes DjangoFilterConnectionField merge to match DjangoConnectionField merge. Along with a couple of tests

This should fix #197 fix #238 fix #244  