### PR TITLE
Update README to reflect that resolve_only_args is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ class User(DjangoObjectType):
 class Query(graphene.ObjectType):
     users = graphene.List(User)
 
-    @graphene.resolve_only_args
     def resolve_users(self):
         return UserModel.objects.all()
 


### PR DESCRIPTION
As resolve_only_args is deprecated, let's remove it from the README.