### PR TITLE
Fix infinite recursion when sublassing DjangoFilterConnectionField

### DIFF
--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -61,7 +61,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         low = default_queryset.query.low_mark or queryset.query.low_mark
         high = default_queryset.query.high_mark or queryset.query.high_mark
         default_queryset.query.clear_limits()
-        queryset = super(cls, cls).merge_querysets(default_queryset, queryset)
+        queryset = super(DjangoFilterConnectionField, cls).merge_querysets(default_queryset, queryset)
         queryset.query.set_limits(low, high)
         return queryset
 


### PR DESCRIPTION
Issue was caused by #224 
if a class is subclassing `DjangoFilterConnectionField` and a queryset is returned from `resolve_schema_field` the `super(cls,cls)` refers back to `DjangoFilterConnectionField` and has an infinite recursion.
I've subclassed `DjangoFilterConnectionField` to add orderby capabilities and it started erroring out because of infinite recursions
possibly a better fix would be
`queryset = DjangoFilterConnectionField.merge_querysets(default_queryset, queryset)`