### PR TITLE
models.DateField => graphene Date Scalar

### DIFF
--- a/examples/starwars/models.py
+++ b/examples/starwars/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 class Character(models.Model):
     name = models.CharField(max_length=50)
-    ship = models.ForeignKey('Ship', blank=True, null=True, related_name='characters')
+    ship = models.ForeignKey('Ship', on_delete=models.CASCADE, blank=True, null=True, related_name='characters')
 
     def __str__(self):
         return self.name
@@ -13,7 +13,7 @@ class Character(models.Model):
 
 class Faction(models.Model):
     name = models.CharField(max_length=50)
-    hero = models.ForeignKey(Character)
+    hero = models.ForeignKey(Character, on_delete=models.CASCADE)
 
     def __str__(self):
         return self.name
@@ -21,7 +21,7 @@ class Faction(models.Model):
 
 class Ship(models.Model):
     name = models.CharField(max_length=50)
-    faction = models.ForeignKey(Faction, related_name='ships')
+    faction = models.ForeignKey(Faction, on_delete=models.CASCADE, related_name='ships')
 
     def __str__(self):
         return self.name

--- a/examples/starwars/models.py
+++ b/examples/starwars/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 class Character(models.Model):
     name = models.CharField(max_length=50)
-    ship = models.ForeignKey('Ship', on_delete=models.CASCADE, blank=True, null=True, related_name='characters')
+    ship = models.ForeignKey('Ship', blank=True, null=True, related_name='characters')
 
     def __str__(self):
         return self.name
@@ -13,7 +13,7 @@ class Character(models.Model):
 
 class Faction(models.Model):
     name = models.CharField(max_length=50)
-    hero = models.ForeignKey(Character, on_delete=models.CASCADE)
+    hero = models.ForeignKey(Character)
 
     def __str__(self):
         return self.name
@@ -21,7 +21,7 @@ class Faction(models.Model):
 
 class Ship(models.Model):
     name = models.CharField(max_length=50)
-    faction = models.ForeignKey(Faction, on_delete=models.CASCADE, related_name='ships')
+    faction = models.ForeignKey(Faction, related_name='ships')
 
     def __str__(self):
         return self.name

--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -5,7 +5,7 @@ from .fields import (
     DjangoConnectionField,
 )
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 __all__ = [
     '__version__',

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -122,7 +122,7 @@ def convert_field_to_float(field, registry=None):
 
 
 @convert_django_field.register(models.DateTimeField)
-def convert_date_to_string(field, registry=None):
+def convert_datetime_to_string(field, registry=None):
     return DateTime(description=field.help_text, required=not field.null)
 
 

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -3,7 +3,7 @@ from django.utils.encoding import force_text
 
 from graphene import (ID, Boolean, Dynamic, Enum, Field, Float, Int, List,
                       NonNull, String, UUID)
-from graphene.types.datetime import DateTime, Time
+from graphene.types.datetime import DateTime, Date, Time
 from graphene.types.json import JSONString
 from graphene.utils.str_converters import to_camel_case, to_const
 from graphql import assert_valid_name
@@ -121,9 +121,14 @@ def convert_field_to_float(field, registry=None):
     return Float(description=field.help_text, required=not field.null)
 
 
-@convert_django_field.register(models.DateField)
+@convert_django_field.register(models.DateTimeField)
 def convert_date_to_string(field, registry=None):
     return DateTime(description=field.help_text, required=not field.null)
+
+
+@convert_django_field.register(models.DateField)
+def convert_date_to_string(field, registry=None):
+    return Date(description=field.help_text, required=not field.null)
 
 
 @convert_django_field.register(models.TimeField)

--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -157,8 +157,8 @@ def test_filter_shortcut_filterset_context():
 
     r1 = Reporter.objects.create(first_name='r1', last_name='r1', email='r1@test.com')
     r2 = Reporter.objects.create(first_name='r2', last_name='r2', email='r2@test.com')
-    Article.objects.create(headline='a1', pub_date=datetime.now(), reporter=r1, editor=r1)
-    Article.objects.create(headline='a2', pub_date=datetime.now(), reporter=r2, editor=r2)
+    Article.objects.create(headline='a1', pub_date=datetime.now(), pub_date_time=datetime.now(), reporter=r1, editor=r1)
+    Article.objects.create(headline='a2', pub_date=datetime.now(), pub_date_time=datetime.now(), reporter=r2, editor=r2)
 
     class context(object):
         reporter = r2
@@ -245,8 +245,8 @@ def test_filter_filterset_related_results():
 
     r1 = Reporter.objects.create(first_name='r1', last_name='r1', email='r1@test.com')
     r2 = Reporter.objects.create(first_name='r2', last_name='r2', email='r2@test.com')
-    Article.objects.create(headline='a1', pub_date=datetime.now(), reporter=r1)
-    Article.objects.create(headline='a2', pub_date=datetime.now(), reporter=r2)
+    Article.objects.create(headline='a1', pub_date=datetime.now(), pub_date_time=datetime.now(), reporter=r1)
+    Article.objects.create(headline='a2', pub_date=datetime.now(), pub_date_time=datetime.now(), reporter=r2)
 
     query = '''
     query {
@@ -464,6 +464,7 @@ def test_should_query_filter_node_limit():
     Article.objects.create(
         headline='Article Node 1',
         pub_date=datetime.now(),
+        pub_date_time=datetime.now(),
         reporter=r,
         editor=r,
         lang='es'
@@ -471,6 +472,7 @@ def test_should_query_filter_node_limit():
     Article.objects.create(
         headline='Article Node 2',
         pub_date=datetime.now(),
+        pub_date_time=datetime.now(),
         reporter=r,
         editor=r,
         lang='en'

--- a/graphene_django/rest_framework/serializer_converter.py
+++ b/graphene_django/rest_framework/serializer_converter.py
@@ -92,7 +92,7 @@ def convert_serializer_field_to_float(field):
 
 
 @get_graphene_type_from_serializer_field.register(serializers.DateTimeField)
-def convert_serializer_field_to_date_time(field):
+def convert_serializer_field_to_datetime_time(field):
     return graphene.types.datetime.DateTime
 
 

--- a/graphene_django/rest_framework/serializer_converter.py
+++ b/graphene_django/rest_framework/serializer_converter.py
@@ -92,9 +92,13 @@ def convert_serializer_field_to_float(field):
 
 
 @get_graphene_type_from_serializer_field.register(serializers.DateTimeField)
-@get_graphene_type_from_serializer_field.register(serializers.DateField)
 def convert_serializer_field_to_date_time(field):
     return graphene.types.datetime.DateTime
+
+
+@get_graphene_type_from_serializer_field.register(serializers.DateField)
+def convert_serializer_field_to_date_time(field):
+    return graphene.types.datetime.Date
 
 
 @get_graphene_type_from_serializer_field.register(serializers.TimeField)

--- a/graphene_django/rest_framework/tests/test_field_converter.py
+++ b/graphene_django/rest_framework/tests/test_field_converter.py
@@ -87,8 +87,8 @@ def test_should_date_time_convert_datetime():
     assert_conversion(serializers.DateTimeField, graphene.types.datetime.DateTime)
 
 
-def test_should_date_convert_datetime():
-    assert_conversion(serializers.DateField, graphene.types.datetime.DateTime)
+def test_should_date_convert_date():
+    assert_conversion(serializers.DateField, graphene.types.datetime.Date)
 
 
 def test_should_time_convert_time():

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -37,6 +37,7 @@ class Reporter(models.Model):
 class Article(models.Model):
     headline = models.CharField(max_length=100)
     pub_date = models.DateField()
+    pub_date_time = models.DateTimeField()
     reporter = models.ForeignKey(Reporter, on_delete=models.CASCADE, related_name='articles')
     editor = models.ForeignKey(Reporter, on_delete=models.CASCADE, related_name='edited_articles_+')
     lang = models.CharField(max_length=2, help_text='Language', choices=[

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -15,7 +15,7 @@ class Pet(models.Model):
 
 class FilmDetails(models.Model):
     location = models.CharField(max_length=30)
-    film = models.OneToOneField('Film', related_name='details')
+    film = models.OneToOneField('Film', on_delete=models.CASCADE, related_name='details')
 
 
 class Film(models.Model):
@@ -37,8 +37,8 @@ class Reporter(models.Model):
 class Article(models.Model):
     headline = models.CharField(max_length=100)
     pub_date = models.DateField()
-    reporter = models.ForeignKey(Reporter, related_name='articles')
-    editor = models.ForeignKey(Reporter, related_name='edited_articles_+')
+    reporter = models.ForeignKey(Reporter, on_delete=models.CASCADE, related_name='articles')
+    editor = models.ForeignKey(Reporter, on_delete=models.CASCADE, related_name='edited_articles_+')
     lang = models.CharField(max_length=2, help_text='Language', choices=[
         ('es', 'Spanish'),
         ('en', 'English')

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -15,7 +15,7 @@ class Pet(models.Model):
 
 class FilmDetails(models.Model):
     location = models.CharField(max_length=30)
-    film = models.OneToOneField('Film', on_delete=models.CASCADE, related_name='details')
+    film = models.OneToOneField('Film', related_name='details')
 
 
 class Film(models.Model):
@@ -38,8 +38,8 @@ class Article(models.Model):
     headline = models.CharField(max_length=100)
     pub_date = models.DateField()
     pub_date_time = models.DateTimeField()
-    reporter = models.ForeignKey(Reporter, on_delete=models.CASCADE, related_name='articles')
-    editor = models.ForeignKey(Reporter, on_delete=models.CASCADE, related_name='edited_articles_+')
+    reporter = models.ForeignKey(Reporter, related_name='articles')
+    editor = models.ForeignKey(Reporter, related_name='edited_articles_+')
     lang = models.CharField(max_length=2, help_text='Language', choices=[
         ('es', 'Spanish'),
         ('en', 'English')

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -5,7 +5,7 @@ from py.test import raises
 
 import graphene
 from graphene.relay import ConnectionField, Node
-from graphene.types.datetime import DateTime, Time
+from graphene.types.datetime import DateTime, Date, Time
 from graphene.types.json import JSONString
 
 from ..compat import JSONField, ArrayField, HStoreField, RangeField, MissingType
@@ -38,9 +38,12 @@ def test_should_unknown_django_field_raise_exception():
         convert_django_field(None)
     assert 'Don\'t know how to convert the Django field' in str(excinfo.value)
 
+def test_should_date_time_convert_string():
+    assert_conversion(models.DateTimeField, DateTime)
+
 
 def test_should_date_convert_string():
-    assert_conversion(models.DateField, DateTime)
+    assert_conversion(models.DateField, Date)
 
 
 def test_should_time_convert_string():

--- a/graphene_django/tests/test_form_converter.py
+++ b/graphene_django/tests/test_form_converter.py
@@ -30,6 +30,8 @@ def test_should_date_convert_string():
 def test_should_time_convert_string():
     assert_conversion(forms.TimeField, graphene.String)
 
+def test_should_date_convert_string():
+    assert_conversion(forms.DateField, graphene.String)
 
 def test_should_date_time_convert_string():
     assert_conversion(forms.DateTimeField, graphene.String)

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -371,6 +371,7 @@ def test_should_query_node_filtering():
     Article.objects.create(
         headline='Article Node 1',
         pub_date=datetime.date.today(),
+        pub_date_time=datetime.datetime.now(),
         reporter=r,
         editor=r,
         lang='es'
@@ -378,6 +379,7 @@ def test_should_query_node_filtering():
     Article.objects.create(
         headline='Article Node 2',
         pub_date=datetime.date.today(),
+        pub_date_time=datetime.datetime.now(),
         reporter=r,
         editor=r,
         lang='en'
@@ -453,6 +455,7 @@ def test_should_query_node_multiple_filtering():
     Article.objects.create(
         headline='Article Node 1',
         pub_date=datetime.date.today(),
+        pub_date_time=datetime.datetime.now(),
         reporter=r,
         editor=r,
         lang='es'
@@ -460,6 +463,7 @@ def test_should_query_node_multiple_filtering():
     Article.objects.create(
         headline='Article Node 2',
         pub_date=datetime.date.today(),
+        pub_date_time=datetime.datetime.now(),
         reporter=r,
         editor=r,
         lang='es'
@@ -467,6 +471,7 @@ def test_should_query_node_multiple_filtering():
     Article.objects.create(
         headline='Article Node 3',
         pub_date=datetime.date.today(),
+        pub_date_time=datetime.datetime.now(),
         reporter=r,
         editor=r,
         lang='en'
@@ -692,6 +697,7 @@ def test_should_query_dataloader_fields():
     Article.objects.create(
         headline='Article Node 1',
         pub_date=datetime.date.today(),
+        pub_date_time=datetime.datetime.now(),
         reporter=r,
         editor=r,
         lang='es'
@@ -699,6 +705,7 @@ def test_should_query_dataloader_fields():
     Article.objects.create(
         headline='Article Node 2',
         pub_date=datetime.date.today(),
+        pub_date_time=datetime.datetime.now(),
         reporter=r,
         editor=r,
         lang='en'

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -64,7 +64,7 @@ def test_django_objecttype_map_correct_fields():
 
 def test_django_objecttype_with_node_have_correct_fields():
     fields = Article._meta.fields
-    assert list(fields.keys()) == ['id', 'headline', 'pub_date', 'reporter', 'editor', 'lang', 'importance']
+    assert list(fields.keys()) == ['id', 'headline', 'pub_date', 'pub_date_time', 'reporter', 'editor', 'lang', 'importance']
 
 
 def test_schema_representation():
@@ -76,7 +76,8 @@ schema {
 type Article implements Node {
   id: ID!
   headline: String!
-  pubDate: DateTime!
+  pubDate: Date!
+  pubDateTime: DateTime!
   reporter: Reporter!
   editor: Reporter!
   lang: ArticleLang!
@@ -103,6 +104,8 @@ enum ArticleLang {
   ES
   EN
 }
+
+scalar Date
 
 scalar DateTime
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
 
     install_requires=[
         'six>=1.10.0',
-        'graphene>=2.0,<3',
+        'graphene>=2.0.1,<3',
         'Django>=1.8.0',
         'iso8601',
         'singledispatch>=3.4.0.3',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ tests_require = [
     'pytest-django==2.9.1',
 ] + rest_framework_require
 
+django_version = 'Django>=1.8.0,<2' if sys.version_info[0] < 3 else 'Django>=1.8.0'
 setup(
     name='graphene-django',
     version=version,
@@ -59,6 +60,7 @@ setup(
         'six>=1.10.0',
         'graphene>=2.0.1,<3',
         'Django>=1.8.0',
+        django_version,
         'iso8601',
         'singledispatch>=3.4.0.3',
         'promise>=2.1',


### PR DESCRIPTION
Currently models.DateField is processed as a DateTime Scalar - this changes it to the new Date Scalar added to graphene

Please note - that the test pass on Django 1.11 - but i was having erros crop up on django 2.0 (1 related to pytest dependancy and the rest was an issue of foreignkeys missing the rel attribute - which i dont think is caused by this)