### PR TITLE
support Django 2 + in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,12 @@ env:
 matrix:
   fast_finish: true
   include:
+  - python: '3.4'
+    env: TEST_TYPE=build DJANGO_VERSION=2.0
+  - python: '3.5'
+    env: TEST_TYPE=build DJANGO_VERSION=2.0
+  - python: '3.6'
+    env: TEST_TYPE=build DJANGO_VERSION=2.0
   - python: '2.7'
     env: TEST_TYPE=build DJANGO_VERSION=1.8
   - python: '2.7'

--- a/examples/starwars/models.py
+++ b/examples/starwars/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 class Character(models.Model):
     name = models.CharField(max_length=50)
-    ship = models.ForeignKey('Ship', blank=True, null=True, related_name='characters')
+    ship = models.ForeignKey('Ship', on_delete=models.CASCADE, blank=True, null=True, related_name='characters')
 
     def __str__(self):
         return self.name
@@ -13,7 +13,7 @@ class Character(models.Model):
 
 class Faction(models.Model):
     name = models.CharField(max_length=50)
-    hero = models.ForeignKey(Character)
+    hero = models.ForeignKey(Character, on_delete=models.CASCADE)
 
     def __str__(self):
         return self.name
@@ -21,7 +21,7 @@ class Faction(models.Model):
 
 class Ship(models.Model):
     name = models.CharField(max_length=50)
-    faction = models.ForeignKey(Faction, related_name='ships')
+    faction = models.ForeignKey(Faction, on_delete=models.CASCADE, related_name='ships')
 
     def __str__(self):
         return self.name

--- a/graphene_django/filter/filterset.py
+++ b/graphene_django/filter/filterset.py
@@ -57,7 +57,7 @@ class GrapheneFilterSetMixin(BaseFilterSet):
         Global IDs (the default implementation expects database
         primary keys)
         """
-        rel = f.field.rel
+        rel = f.field.remote_field
         default = {
             'name': name,
             'label': capfirst(rel.related_name)

--- a/graphene_django/filter/filterset.py
+++ b/graphene_django/filter/filterset.py
@@ -57,7 +57,6 @@ class GrapheneFilterSetMixin(BaseFilterSet):
         Global IDs (the default implementation expects database
         primary keys)
         """
-        
         try:
             rel = f.field.remote_field
         except AttributeError:

--- a/graphene_django/filter/filterset.py
+++ b/graphene_django/filter/filterset.py
@@ -57,7 +57,10 @@ class GrapheneFilterSetMixin(BaseFilterSet):
         Global IDs (the default implementation expects database
         primary keys)
         """
-        rel = f.field.remote_field
+        try:
+            rel = f.field.remote_field
+        except AttributeError:
+            rel = f.field.rel
         default = {
             'name': name,
             'label': capfirst(rel.related_name)

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -15,7 +15,7 @@ class Pet(models.Model):
 
 class FilmDetails(models.Model):
     location = models.CharField(max_length=30)
-    film = models.OneToOneField('Film', related_name='details')
+    film = models.OneToOneField('Film', on_delete=models.CASCADE, related_name='details')
 
 
 class Film(models.Model):
@@ -37,8 +37,8 @@ class Reporter(models.Model):
 class Article(models.Model):
     headline = models.CharField(max_length=100)
     pub_date = models.DateField()
-    reporter = models.ForeignKey(Reporter, related_name='articles')
-    editor = models.ForeignKey(Reporter, related_name='edited_articles_+')
+    reporter = models.ForeignKey(Reporter, on_delete=models.CASCADE, related_name='articles')
+    editor = models.ForeignKey(Reporter, on_delete=models.CASCADE, related_name='edited_articles_+')
     lang = models.CharField(max_length=2, help_text='Language', choices=[
         ('es', 'Spanish'),
         ('en', 'English')

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ tests_require = [
     'pytest-django==2.9.1',
 ] + rest_framework_require
 
+django_version = 'Django>=1.8.0,<2' if sys.version_info[0] < 3 else 'Django>=1.8.0'
 setup(
     name='graphene-django',
     version=version,
@@ -58,7 +59,7 @@ setup(
     install_requires=[
         'six>=1.10.0',
         'graphene>=2.0,<3',
-        'Django>=1.8.0',
+        django_version,
         'iso8601',
         'singledispatch>=3.4.0.3',
         'promise>=2.1',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ tests_require = [
     'mock',
     'pytz',
     'django-filter',
-    'pytest-django==2.9.1',
+    'pytest-django>=3.2.1',
 ] + rest_framework_require
 
 django_version = 'Django>=1.8.0,<2' if sys.version_info[0] < 3 else 'Django>=1.8.0'


### PR DESCRIPTION
Foreign keys in Django 2 require an on_delete attribute
Also the field.rel attribute has been deprecated as of Django 2 and is now field.remote_field
I have added a fallback for 1.8

[The django docs specifying the changes to field.rel](https://docs.djangoproject.com/en/1.9/releases/1.9/#field-rel-changes)