### PR TITLE
Fixing the test build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ tests_require = [
     'pytest-django==2.9.1',
 ] + rest_framework_require
 
+django_version = 'Django>=1.8.0,<2' if sys.version_info[0] < 3 else 'Django>=1.8.0'
 setup(
     name='graphene-django',
     version=version,
@@ -58,7 +59,7 @@ setup(
     install_requires=[
         'six>=1.10.0',
         'graphene>=2.0,<3',
-        'Django>=1.8.0',
+        django_version,
         'iso8601',
         'singledispatch>=3.4.0.3',
         'promise>=2.1',


### PR DESCRIPTION
Several PRs are failing for unrelated reasons. Figuring out those reasons and getting the build passing again...

It looks like there is just one issue:

Django 2.0 is released and we aren't ready for that yet. #336 will fix it completely, but for now, we just need to not install 2.0 on python 2.7