### PR TITLE
Upgrade graphiql and react versions

### DIFF
--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -16,11 +16,11 @@ add "&raw" to the end of the URL within a browser.
       width: 100%;
     }
   </style>
-  <link href="//cdn.jsdelivr.net/graphiql/{{graphiql_version}}/graphiql.css" rel="stylesheet" />
-  <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.0.1/react.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.0.1/react-dom.min.js"></script>
-  <script src="//cdn.jsdelivr.net/graphiql/{{graphiql_version}}/graphiql.min.js"></script>
+  <link href="//cdn.jsdelivr.net/npm/graphiql@{{graphiql_version}}/graphiql.css" rel="stylesheet" />
+  <script src="//cdn.jsdelivr.net/npm/whatwg-fetch@2.0.3/fetch.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/react@16.2.0/umd/react.production.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/react-dom@16.2.0/umd/react-dom.production.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/graphiql@{{graphiql_version}}/graphiql.min.js"></script>
 </head>
 <body>
   <script>

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -53,7 +53,7 @@ def instantiate_middleware(middlewares):
 
 
 class GraphQLView(View):
-    graphiql_version = '0.10.2'
+    graphiql_version = '0.11.10'
     graphiql_template = 'graphene/graphiql.html'
 
     schema = None


### PR DESCRIPTION
jsdelivr seems to have adopted a new url scheme. I also couldn't find a browser version of the `fetch` package so I switched to the `whatwg-fetch` package.