### PR TITLE
updated path to graphene favicon in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Please read [UPGRADE-v2.0.md](https://github.com/graphql-python/graphene/blob/ma
 
 ---
 
-# ![Graphene Logo](http://graphene-python.org/favicon.png) Graphene-Django [![Build Status](https://travis-ci.org/graphql-python/graphene-django.svg?branch=master)](https://travis-ci.org/graphql-python/graphene-django) [![PyPI version](https://badge.fury.io/py/graphene-django.svg)](https://badge.fury.io/py/graphene-django) [![Coverage Status](https://coveralls.io/repos/graphql-python/graphene-django/badge.svg?branch=master&service=github)](https://coveralls.io/github/graphql-python/graphene-django?branch=master)
+# ![Graphene Logo](https://github.com/graphql-python/graphene-python.org/raw/master/pages/favicon.png) Graphene-Django [![Build Status](https://travis-ci.org/graphql-python/graphene-django.svg?branch=master)](https://travis-ci.org/graphql-python/graphene-django) [![PyPI version](https://badge.fury.io/py/graphene-django.svg)](https://badge.fury.io/py/graphene-django) [![Coverage Status](https://coveralls.io/repos/graphql-python/graphene-django/badge.svg?branch=master&service=github)](https://coveralls.io/github/graphql-python/graphene-django?branch=master)
 
 
 A [Django](https://www.djangoproject.com/) integration for [Graphene](http://graphene-python.org/).

--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ Then to produce a HTML version of the documentation:
 
     make html
 
-.. |Graphene Logo| image:: http://graphene-python.org/favicon.png
+.. |Graphene Logo| image:: https://github.com/graphql-python/graphene-python.org/raw/master/pages/favicon.png
 .. |Build Status| image:: https://travis-ci.org/graphql-python/graphene-django.svg?branch=master
    :target: https://travis-ci.org/graphql-python/graphene-django
 .. |PyPI version| image:: https://badge.fury.io/py/graphene-django.svg


### PR DESCRIPTION
In both README.md and README.rst path to graphene's favicon is a dead end.

I've linked the favicon straight from the main graphene-python.org repo and now it displays properly.
 
Before:
<img width="844" alt="screen shot 2018-01-05 at 10 56 21" src="https://user-images.githubusercontent.com/3473617/34604176-2ccf3d84-f207-11e7-95b3-069053d77830.png">

After:
<img width="642" alt="screen shot 2018-01-05 at 10 56 08" src="https://user-images.githubusercontent.com/3473617/34604185-3425fd0c-f207-11e7-8952-b7fa68418144.png">
