### PR TITLE
Fix Django Rest Framework version when testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     pip install -e .[test]
     pip install psycopg2 # Required for Django postgres fields testing
     pip install django==$DJANGO_VERSION
-    if [ $DJANGO_VERSION = 1.8 ]; then # DRF dropped 1.8 support at 3.7.0
+    if (($(echo "$DJANGO_VERSION <= 1.9" | bc -l))); then # DRF dropped 1.8 and 1.9 support at 3.7.0
       pip install djangorestframework==3.6.4
     fi
     python setup.py develop


### PR DESCRIPTION
Version 3.7 has removed support for anything less than 1.10, see here: http://www.django-rest-framework.org/topics/3.7-announcement/