### PR TITLE
Fixes #371 - Support ListSerializer fields in SerializerMutation

### DIFF
--- a/graphene_django/rest_framework/serializer_converter.py
+++ b/graphene_django/rest_framework/serializer_converter.py
@@ -46,6 +46,15 @@ def convert_serializer_field(field, is_input=True):
             global_registry = get_global_registry()
             field_model = field.Meta.model
             args = [global_registry.get_type_for_model(field_model)]
+    elif isinstance(field, serializers.ListSerializer):
+        field = field.child
+        if is_input:
+            kwargs['of_type'] = convert_serializer_to_input_type(field.__class__)
+        else:
+            del kwargs['of_type']
+            global_registry = get_global_registry()
+            field_model = field.Meta.model
+            args = [global_registry.get_type_for_model(field_model)]
 
     return graphql_type(*args, **kwargs)
 
@@ -73,6 +82,12 @@ def convert_serializer_field_to_string(field):
 @get_graphene_type_from_serializer_field.register(serializers.ModelSerializer)
 def convert_serializer_to_field(field):
     return graphene.Field
+
+
+@get_graphene_type_from_serializer_field.register(serializers.ListSerializer)
+def convert_list_serializer_to_field(field):
+    child_type = get_graphene_type_from_serializer_field(field.child)
+    return (graphene.List, child_type)
 
 
 @get_graphene_type_from_serializer_field.register(serializers.IntegerField)


### PR DESCRIPTION
This allows SerializerMutation to handle serializer fields with `many=True`. 

Fixes #371 

e.g. having these serializers
```python
class CategorySerializer(ModelSerializer):
    name = serializers.CharField()

    class Meta:
        model = Category
        fields = '__all__'


class ProductSerializer(ModelSerializer):
    description = serializers.CharField()
    category = CategorySerializer(many=True)

    class Meta:
        model = Product
        fields = '__all__'

```
... and this mutation
```python
class CreateProduct(SerializerMutation):
    class Meta:
        serializer_class = ProductSerializer
```

enables nested objects in in the queries:
```graphql
mutation {
	createProduct(input:{
    description: "Product description",
    category: [
      {name: "Category 1"}
    ]
  }) {
    id
  }
}
```
