### PR TITLE
Fixes #400

### DIFF
--- a/graphene_django/filter/filterset.py
+++ b/graphene_django/filter/filterset.py
@@ -57,7 +57,7 @@ class GrapheneFilterSetMixin(BaseFilterSet):
         Global IDs (the default implementation expects database
         primary keys)
         """
-        rel = f.field.rel
+        rel = f.field.remote_field
         default = {
             'name': name,
             'label': capfirst(rel.related_name)

--- a/graphene_django/filter/filterset.py
+++ b/graphene_django/filter/filterset.py
@@ -57,7 +57,7 @@ class GrapheneFilterSetMixin(BaseFilterSet):
         Global IDs (the default implementation expects database
         primary keys)
         """
-        rel = f.field.remote_field
+        rel = f.field.remote_field if hasattr(f.field, 'remote_field') else f.field.rel
         default = {
             'name': name,
             'label': capfirst(rel.related_name)


### PR DESCRIPTION
After more digging than I expected (and planned), I'm 99% sure that the problem comes from `graphene_django`. I checked (as much as I could) the source codes of: [Django](https://github.com/django/django), [Graphene](https://github.com/graphql-python/graphene), and [Django Filter](https://github.com/carltongibson/django-filter) (and this one of course).

I found a [comment](https://github.com/django/django/blob/16436f3751e9eec67a7b80b25c8e7d29a34be67e/django/db/models/fields/reverse_related.py#L4-L6) in Django's source that refers to an attribute named `remote_field`, instead of `rel`.

It seamed to fix the problem for me without any other bugs (yet).