### PR TITLE
Added auto M2M

### DIFF
--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -43,8 +43,9 @@ def get_model_fields(model):
     local_fields = [
         (field.name, field)
         for field
-        in sorted(list(model._meta.fields) +
-                  list(model._meta.local_many_to_many))
+        in sorted(set(list(model._meta.fields) +
+                  list(model._meta.many_to_many) +
+                  list(model._meta.local_many_to_many)))
     ]
 
     # Make sure we don't duplicate local fields with "reverse" version


### PR DESCRIPTION
Maybe it isn't the correct solution, but I wasn't able to have my `ManyToManyField` used.

Without this patch I receive: ```{
  "errors": [
    {
      "message": "Cannot query field \"mymanyfield\" on type \"MyModelWithManyNode\".",
      "locations": [
        {
          "line": 4,
          "column": 5
        }
      ]
    }
  ]
}```

I made this patch from 2.0.0 as 2.0.1 doesn't work with my config.