### PR TITLE
Pin an explicit version of django-filter (<2) on cookbook example

### DIFF
--- a/examples/cookbook/requirements.txt
+++ b/examples/cookbook/requirements.txt
@@ -2,4 +2,4 @@ graphene
 graphene-django
 graphql-core>=2.1rc1
 django==1.9
-django-filter==0.11.0
+django-filter<2


### PR DESCRIPTION
With requirements set with `django-filter==0.11.0`, the cookbook example is unable to execute query using filters. Leading to a `TypeError` :

`__init__() got an unexpected keyword argument 'request'`

Due to [line 95 in filter/fields.py](https://github.com/graphql-python/graphene-django/blob/master/graphene_django/filter/fields.py#L95)

Pin it to the same requirements as [graphene-django itself](https://github.com/graphql-python/graphene-django/blob/master/setup.py#L22).