### PR TITLE
one to one ModelSerializer mutations

### DIFF
--- a/examples/starwars/schema.py
+++ b/examples/starwars/schema.py
@@ -1,12 +1,14 @@
 import graphene
 from graphene import Schema, relay, resolve_only_args
 from graphene_django import DjangoConnectionField, DjangoObjectType
+from graphene_django.rest_framework.mutation import SerializerMutation
 
 from .data import (create_ship, get_empire, get_faction, get_rebels, get_ship,
                    get_ships)
 from .models import Character as CharacterModel
 from .models import Faction as FactionModel
 from .models import Ship as ShipModel
+from .serializers import CharacterSerializer
 
 
 class Ship(DjangoObjectType):
@@ -54,6 +56,11 @@ class IntroduceShip(relay.ClientIDMutation):
         return IntroduceShip(ship=ship, faction=faction)
 
 
+class CreateCharacter(SerializerMutation):
+    class Meta:
+        serializer_class = CharacterSerializer
+
+
 class Query(graphene.ObjectType):
     rebels = graphene.Field(Faction)
     empire = graphene.Field(Faction)
@@ -75,7 +82,7 @@ class Query(graphene.ObjectType):
 
 class Mutation(graphene.ObjectType):
     introduce_ship = IntroduceShip.Field()
-
+    create_character = CreateCharacter.Field()
 
 # We register the Character Model because if not would be
 # inaccessible for the schema

--- a/examples/starwars/serializers.py
+++ b/examples/starwars/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from .models import Character
+
+
+class CharacterSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Character
+        fields = "__all__"

--- a/examples/starwars/tests/test_mutation.py
+++ b/examples/starwars/tests/test_mutation.py
@@ -77,3 +77,33 @@ def test_mutations():
     result = schema.execute(query)
     assert not result.errors
     assert result.data == expected
+
+
+def test_serializer_mutations():
+    initialize()
+
+    query = '''
+    mutation createCharacter {
+      createCharacter(input:{clientMutationId:"def", name: "Luke", ship: "1"}) {
+        id
+        name
+        ship {
+          id
+          name
+        }
+      }
+    }
+    '''
+    expected = {
+        'createCharacter': {
+            'id': 3,
+            'name': 'Luke',
+            'ship': {
+                'id': 'U2hpcDox',
+                'name': 'X-Wing'
+            }
+        }
+    }
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data == expected

--- a/graphene_django/rest_framework/models.py
+++ b/graphene_django/rest_framework/models.py
@@ -4,3 +4,9 @@ from django.db import models
 class MyFakeModel(models.Model):
     cool_name = models.CharField(max_length=50)
     created = models.DateTimeField(auto_now_add=True)
+
+
+class OneToOneModel(models.Model):
+    name = models.CharField(max_length=50)
+    fake = models.ForeignKey(MyFakeModel, on_delete=models.DO_NOTHING)
+    created = models.DateTimeField(auto_now_add=True)

--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -138,6 +138,9 @@ class SerializerMutation(ClientIDMutation):
 
         kwargs = {}
         for f, field in serializer.fields.items():
-            kwargs[f] = field.get_attribute(obj)
+            if hasattr(field, 'queryset'):
+                kwargs[f] = field.queryset.get(pk=str(field.get_attribute(obj)))
+            else:
+                kwargs[f] = field.get_attribute(obj)
 
         return cls(errors=None, **kwargs)

--- a/graphene_django/rest_framework/serializer_converter.py
+++ b/graphene_django/rest_framework/serializer_converter.py
@@ -58,7 +58,6 @@ def convert_serializer_field(field, is_input=True):
             field_model = field.Meta.model
             args = [global_registry.get_type_for_model(field_model)]
 
-    print('graphql_type', graphql_type, args)
     return graphql_type(*args, **kwargs)
 
 


### PR DESCRIPTION
Hey there,

First of all, this project is fantastic!

I've been attempting to slowly apply `graphene-django` to some of the models/endpoints we use at work, and struggled with writing mutations over `ModelSerializer`s.

If you consider the Star Wars example, where every `Character` has a `Ship`, it would be pretty normal to write a `CharacterSerializer` like this:
```py
class CharacterSerializer(serializers.ModelSerializer):
    class Meta:
        model = Character
        fields = "__all__"
```
This will include a field `ship` of class `PrimaryKeyRelatedField`

To use this serializer to power a GQL mutation, you'd like to write something really clean like this:
```py
class CreateCharacter(SerializerMutation):
    class Meta:
        serializer_class = CharacterSerializer
```

Currently, this mutation will run, but the response won't match the GQL we expect:

```gql
# what we would expect
mutation createCharacter(name: String, ship: ID) {
    id
    name
    ship {
        id
        name
    }
    errors {
        messages	
    }
}

# what it creates
mutation createCharacter(name: String, ship: ID) {
    id
    name
    ship # a String :/
    errors {
        messages	
    }
}
```

You could roll your own mutation like in the star wars example:
https://github.com/graphql-python/graphene-django/blob/52d14f3b8ace2a3de0e3d07a597539390277ed2b/examples/starwars/schema.py#L41
but it would be great to support DRF `ModelSerializer` out of the box (we use DRF all over our codebase, often with complex validation)

This is a first crack at solving this problem. More work would be needed to support M2M relationships, but I wanted to get this in front of y'all first and get some feedback first.

Let me know what you think!