### PR TITLE
Add Introspection Schema Link in Documentation

### DIFF
--- a/docs/tutorial-relay.rst
+++ b/docs/tutorial-relay.rst
@@ -345,3 +345,10 @@ Or you can get only 'meat' ingredients containing the letter 'e':
         }
       }
     }
+
+
+
+Final Steps
+^^^^^^^^^^^
+
+We have created a GraphQL endpoint that will work with Relay, but for Relay to work it needs access to a (non python) schema. Instructions to export the schema can be found on the `Introspection Schema <http://docs.graphene-python.org/projects/django/en/latest/introspection/>`__ part of this guide.


### PR DESCRIPTION
By the end of the Graphene and Django Tutorial using Relay, one might think they have finished everything needed server side for Relay, but six sections later, in a section that doesn't mention Relay in the title, the final required step for Relay is documented.