### PR TITLE
Mention filter incompatibility with django 2.0

### DIFF
--- a/docs/filtering.rst
+++ b/docs/filtering.rst
@@ -3,7 +3,9 @@ Filtering
 
 Graphene integrates with
 `django-filter <https://django-filter.readthedocs.io/en/1.1.0/>`__ (< 2.0.0) to provide
-filtering of results. See the `usage
+filtering of results (this also means filtering is only compatible with Django < 2.0).
+
+See the `usage
 documentation <https://django-filter.readthedocs.io/en/1.1.0/guide/usage.html#the-filter>`__
 for details on the format for ``filter_fields``.
 


### PR DESCRIPTION
Was in the process of updating our app to Python 3 + Django 2.1 and ran into this (would've been nice if it was mentioned in the docs).

Related: https://github.com/graphql-python/graphene-django/issues/464