### PR TITLE
Improve Security of GraphiQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ pip install "graphene-django>=2.0"
 ```python
 INSTALLED_APPS = (
     # ...
+    'django.contrib.staticfiles', # Required for GraphiQL
     'graphene_django',
 )
 

--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -35,30 +35,10 @@
     }
   }
 
-  // If there are any fragment parameters, confirm the user wants to use them.
-  var isReload = window.performance ? performance.navigation.type === 1 : false;
-  var isQueryTrusted = Object.keys(parameters).length === 0 || isReload;
-
   var fetchURL = locationQuery(otherParams);
 
   // Defines a GraphQL fetcher using the fetch API.
   function graphQLFetcher(graphQLParams) {
-    var isIntrospectionQuery = (
-      graphQLParams.query !== parameters.query
-      && graphQLParams.query.indexOf('IntrospectionQuery') !== -1
-    );
-
-    if (!isQueryTrusted
-      && !isIntrospectionQuery
-      && !window.confirm("This query was loaded from a link, are you sure you want to execute it?")) {
-      return Promise.resolve('Aborting query.');
-    }
-
-    // We don't want to set this for the introspection query
-    if (!isIntrospectionQuery) {
-      isQueryTrusted = true;
-    }
-
     var headers = {
       'Accept': 'application/json',
       'Content-Type': 'application/json'

--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -1,0 +1,119 @@
+(function() {
+
+  // Parse the cookie value for a CSRF token
+  var csrftoken;
+  var cookies = ('; ' + document.cookie).split('; csrftoken=');
+  if (cookies.length == 2)
+    csrftoken = cookies.pop().split(';').shift();
+
+  // Collect the URL parameters
+  var parameters = {};
+  window.location.hash.substr(1).split('&').forEach(function (entry) {
+    var eq = entry.indexOf('=');
+    if (eq >= 0) {
+      parameters[decodeURIComponent(entry.slice(0, eq))] =
+        decodeURIComponent(entry.slice(eq + 1));
+    }
+  });
+  // Produce a Location fragment string from a parameter object.
+  function locationQuery(params) {
+    return '#' + Object.keys(params).map(function (key) {
+      return encodeURIComponent(key) + '=' +
+        encodeURIComponent(params[key]);
+    }).join('&');
+  }
+  // Derive a fetch URL from the current URL, sans the GraphQL parameters.
+  var graphqlParamNames = {
+    query: true,
+    variables: true,
+    operationName: true
+  };
+  var otherParams = {};
+  for (var k in parameters) {
+    if (parameters.hasOwnProperty(k) && graphqlParamNames[k] !== true) {
+      otherParams[k] = parameters[k];
+    }
+  }
+
+  // If there are any fragment parameters, confirm the user wants to use them.
+  var isReload = window.performance ? performance.navigation.type === 1 : false;
+  var isQueryTrusted = Object.keys(parameters).length === 0 || isReload;
+
+  var fetchURL = locationQuery(otherParams);
+
+  // Defines a GraphQL fetcher using the fetch API.
+  function graphQLFetcher(graphQLParams) {
+    var isIntrospectionQuery = (
+      graphQLParams.query !== parameters.query
+      && graphQLParams.query.indexOf('IntrospectionQuery') !== -1
+    );
+
+    if (!isQueryTrusted
+      && !isIntrospectionQuery
+      && !window.confirm("This query was loaded from a link, are you sure you want to execute it?")) {
+      return Promise.resolve('Aborting query.');
+    }
+
+    // We don't want to set this for the introspection query
+    if (!isIntrospectionQuery) {
+      isQueryTrusted = true;
+    }
+
+    var headers = {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    };
+    if (csrftoken) {
+      headers['X-CSRFToken'] = csrftoken;
+    }
+    return fetch(fetchURL, {
+      method: 'post',
+      headers: headers,
+      body: JSON.stringify(graphQLParams),
+      credentials: 'include',
+    }).then(function (response) {
+      return response.text();
+    }).then(function (responseBody) {
+      try {
+        return JSON.parse(responseBody);
+      } catch (error) {
+        return responseBody;
+      }
+    });
+  }
+  // When the query and variables string is edited, update the URL bar so
+  // that it can be easily shared.
+  function onEditQuery(newQuery) {
+    parameters.query = newQuery;
+    updateURL();
+  }
+  function onEditVariables(newVariables) {
+    parameters.variables = newVariables;
+    updateURL();
+  }
+  function onEditOperationName(newOperationName) {
+    parameters.operationName = newOperationName;
+    updateURL();
+  }
+  function updateURL() {
+    history.replaceState(null, null, locationQuery(parameters));
+  }
+  var options = {
+    fetcher: graphQLFetcher,
+      onEditQuery: onEditQuery,
+      onEditVariables: onEditVariables,
+      onEditOperationName: onEditOperationName,
+      query: parameters.query,
+  }
+  if (parameters.variables) {
+    options.variables = parameters.variables;
+  }
+  if (parameters.operation_name) {
+    options.operationName = parameters.operation_name;
+  }
+  // Render <GraphiQL /> into the body.
+  ReactDOM.render(
+    React.createElement(GraphiQL, options),
+    document.body
+  );
+})();

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -100,22 +100,27 @@ add "&raw" to the end of the URL within a browser.
     function updateURL() {
       history.replaceState(null, null, locationQuery(parameters));
     }
-    // Render <GraphiQL /> into the body.
-    ReactDOM.render(
-      React.createElement(GraphiQL, {
-        fetcher: graphQLFetcher,
+    // If there are any fragment parameters, confirm the user wants to use them.
+    if (Object.keys(parameters).length
+      && !window.confirm("An untrusted query has been loaded, continue loading query?")) {
+      parameters = {};
+    }
+    var options = {
+      fetcher: graphQLFetcher,
         onEditQuery: onEditQuery,
         onEditVariables: onEditVariables,
         onEditOperationName: onEditOperationName,
-        query: '{{ query|escapejs }}',
-        response: '{{ result|escapejs }}',
-        {% if variables %}
-        variables: '{{ variables|escapejs }}',
-        {% endif %}
-        {% if operation_name %}
-        operationName: '{{ operation_name|escapejs }}',
-        {% endif %}
-      }),
+        query: parameters.query,
+    }
+    if (parameters.variables) {
+      options.variables = parameters.variables;
+    }
+    if (parameters.operation_name) {
+      options.operationName = parameters.operation_name;
+    }
+    // Render <GraphiQL /> into the body.
+    ReactDOM.render(
+      React.createElement(GraphiQL, options),
       document.body
     );
   </script>

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -24,6 +24,6 @@ add "&raw" to the end of the URL within a browser.
   <script src="//cdn.jsdelivr.net/npm/graphiql@{{graphiql_version}}/graphiql.min.js"></script>
 </head>
 <body>
-  <script src="{% static "graphene_django/graphiql.js" %}"></script>
+  <script src="{% static 'graphene_django/graphiql.js' %}"></script>
 </body>
 </html>

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -32,7 +32,7 @@ add "&raw" to the end of the URL within a browser.
 
     // Collect the URL parameters
     var parameters = {};
-    window.location.search.substr(1).split('&').forEach(function (entry) {
+    window.location.hash.substr(1).split('&').forEach(function (entry) {
       var eq = entry.indexOf('=');
       if (eq >= 0) {
         parameters[decodeURIComponent(entry.slice(0, eq))] =
@@ -41,7 +41,7 @@ add "&raw" to the end of the URL within a browser.
     });
     // Produce a Location query string from a parameter object.
     function locationQuery(params) {
-      return '?' + Object.keys(params).map(function (key) {
+      return '#' + Object.keys(params).map(function (key) {
         return encodeURIComponent(key) + '=' +
           encodeURIComponent(params[key]);
       }).join('&');

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -5,6 +5,7 @@ exploring GraphQL.
 If you wish to receive JSON, provide the header "Accept: application/json" or
 add "&raw" to the end of the URL within a browser.
 -->
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -23,123 +24,6 @@ add "&raw" to the end of the URL within a browser.
   <script src="//cdn.jsdelivr.net/npm/graphiql@{{graphiql_version}}/graphiql.min.js"></script>
 </head>
 <body>
-  <script>
-    // Parse the cookie value for a CSRF token
-    var csrftoken;
-    var cookies = ('; ' + document.cookie).split('; csrftoken=');
-    if (cookies.length == 2)
-      csrftoken = cookies.pop().split(';').shift();
-
-    // Collect the URL parameters
-    var parameters = {};
-    window.location.hash.substr(1).split('&').forEach(function (entry) {
-      var eq = entry.indexOf('=');
-      if (eq >= 0) {
-        parameters[decodeURIComponent(entry.slice(0, eq))] =
-          decodeURIComponent(entry.slice(eq + 1));
-      }
-    });
-    // Produce a Location fragment string from a parameter object.
-    function locationQuery(params) {
-      return '#' + Object.keys(params).map(function (key) {
-        return encodeURIComponent(key) + '=' +
-          encodeURIComponent(params[key]);
-      }).join('&');
-    }
-    // Derive a fetch URL from the current URL, sans the GraphQL parameters.
-    var graphqlParamNames = {
-      query: true,
-      variables: true,
-      operationName: true
-    };
-    var otherParams = {};
-    for (var k in parameters) {
-      if (parameters.hasOwnProperty(k) && graphqlParamNames[k] !== true) {
-        otherParams[k] = parameters[k];
-      }
-    }
-
-    // If there are any fragment parameters, confirm the user wants to use them.
-    var isReload = window.performance ? performance.navigation.type === 1 : false;
-    var isQueryTrusted = Object.keys(parameters).length === 0 || isReload;
-
-    var fetchURL = locationQuery(otherParams);
-
-    // Defines a GraphQL fetcher using the fetch API.
-    function graphQLFetcher(graphQLParams) {
-      var isIntrospectionQuery = (
-        graphQLParams.query !== parameters.query
-        && graphQLParams.query.indexOf('IntrospectionQuery') !== -1
-      );
-
-      if (!isQueryTrusted
-        && !isIntrospectionQuery
-        && !window.confirm("This query was loaded from a link, are you sure you want to execute it?")) {
-        return Promise.resolve('Aborting query.');
-      }
-
-      // We don't want to set this for the introspection query
-      if (!isIntrospectionQuery) {
-        isQueryTrusted = true;
-      }
-
-      var headers = {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      };
-      if (csrftoken) {
-        headers['X-CSRFToken'] = csrftoken;
-      }
-      return fetch(fetchURL, {
-        method: 'post',
-        headers: headers,
-        body: JSON.stringify(graphQLParams),
-        credentials: 'include',
-      }).then(function (response) {
-        return response.text();
-      }).then(function (responseBody) {
-        try {
-          return JSON.parse(responseBody);
-        } catch (error) {
-          return responseBody;
-        }
-      });
-    }
-    // When the query and variables string is edited, update the URL bar so
-    // that it can be easily shared.
-    function onEditQuery(newQuery) {
-      parameters.query = newQuery;
-      updateURL();
-    }
-    function onEditVariables(newVariables) {
-      parameters.variables = newVariables;
-      updateURL();
-    }
-    function onEditOperationName(newOperationName) {
-      parameters.operationName = newOperationName;
-      updateURL();
-    }
-    function updateURL() {
-      history.replaceState(null, null, locationQuery(parameters));
-    }
-    var options = {
-      fetcher: graphQLFetcher,
-        onEditQuery: onEditQuery,
-        onEditVariables: onEditVariables,
-        onEditOperationName: onEditOperationName,
-        query: parameters.query,
-    }
-    if (parameters.variables) {
-      options.variables = parameters.variables;
-    }
-    if (parameters.operation_name) {
-      options.operationName = parameters.operation_name;
-    }
-    // Render <GraphiQL /> into the body.
-    ReactDOM.render(
-      React.createElement(GraphiQL, options),
-      document.body
-    );
-  </script>
+  <script src="{% static "graphene_django/graphiql.js" %}"></script>
 </body>
 </html>

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -39,7 +39,7 @@ add "&raw" to the end of the URL within a browser.
           decodeURIComponent(entry.slice(eq + 1));
       }
     });
-    // Produce a Location query string from a parameter object.
+    // Produce a Location fragment string from a parameter object.
     function locationQuery(params) {
       return '#' + Object.keys(params).map(function (key) {
         return encodeURIComponent(key) + '=' +

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -58,9 +58,31 @@ add "&raw" to the end of the URL within a browser.
         otherParams[k] = parameters[k];
       }
     }
+
+    // If there are any fragment parameters, confirm the user wants to use them.
+    var isReload = window.performance ? performance.navigation.type === 1 : false;
+    var isQueryTrusted = Object.keys(parameters).length === 0 || isReload;
+
     var fetchURL = locationQuery(otherParams);
+
     // Defines a GraphQL fetcher using the fetch API.
     function graphQLFetcher(graphQLParams) {
+      var isIntrospectionQuery = (
+        graphQLParams.query !== parameters.query
+        && graphQLParams.query.indexOf('IntrospectionQuery') !== -1
+      );
+
+      if (!isQueryTrusted
+        && !isIntrospectionQuery
+        && !window.confirm("This query was loaded from a link, are you sure you want to execute it?")) {
+        return Promise.resolve('Aborting query.');
+      }
+
+      // We don't want to set this for the introspection query
+      if (!isIntrospectionQuery) {
+        isQueryTrusted = true;
+      }
+
       var headers = {
         'Accept': 'application/json',
         'Content-Type': 'application/json'
@@ -99,13 +121,6 @@ add "&raw" to the end of the URL within a browser.
     }
     function updateURL() {
       history.replaceState(null, null, locationQuery(parameters));
-    }
-    // If there are any fragment parameters, confirm the user wants to use them.
-    var isReload = window.performance ? performance.navigation.type === 1 : false;
-    if (Object.keys(parameters).length
-      && !isReload
-      && !window.confirm("An untrusted query has been loaded, continue loading query?")) {
-      parameters = {};
     }
     var options = {
       fetcher: graphQLFetcher,

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -101,7 +101,9 @@ add "&raw" to the end of the URL within a browser.
       history.replaceState(null, null, locationQuery(parameters));
     }
     // If there are any fragment parameters, confirm the user wants to use them.
+    var isReload = window.performance ? performance.navigation.type === 1 : false;
     if (Object.keys(parameters).length
+      && !isReload
       && !window.confirm("An untrusted query has been loaded, continue loading query?")) {
       parameters = {};
     }

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -124,6 +124,12 @@ class GraphQLView(View):
             data = self.parse_body(request)
             show_graphiql = self.graphiql and self.can_display_graphiql(request, data)
 
+            if show_graphiql:
+                return self.render_graphiql(
+                    request,
+                    graphiql_version=self.graphiql_version,
+                )
+
             if self.batch:
                 responses = [self.get_response(request, entry) for entry in data]
                 result = "[{}]".format(
@@ -136,19 +142,6 @@ class GraphQLView(View):
                 )
             else:
                 result, status_code = self.get_response(request, data, show_graphiql)
-
-            if show_graphiql:
-                query, variables, operation_name, id = self.get_graphql_params(
-                    request, data
-                )
-                return self.render_graphiql(
-                    request,
-                    graphiql_version=self.graphiql_version,
-                    query=query or "",
-                    variables=json.dumps(variables) or "",
-                    operation_name=operation_name or "",
-                    result=result or "",
-                )
 
             return HttpResponse(
                 status=status_code, content=result, content_type="application/json"


### PR DESCRIPTION
This PR makes the following security improvements to GraphiQL in graphene-django.

 - Stores the GraphQL query in the URL fragment, rather than the query, so that sensitive data won't be logged to web server logs.
 - Moves JS to a separate file to enable stricter Content Security Policies.
