### PR TITLE
Document Django Debug types

### DIFF
--- a/graphene_django/debug/sql/types.py
+++ b/graphene_django/debug/sql/types.py
@@ -2,19 +2,53 @@ from graphene import Boolean, Float, ObjectType, String
 
 
 class DjangoDebugSQL(ObjectType):
-    vendor = String()
-    alias = String()
-    sql = String()
-    duration = Float()
-    raw_sql = String()
-    params = String()
-    start_time = Float()
-    stop_time = Float()
-    is_slow = Boolean()
-    is_select = Boolean()
+    class Meta:
+        description = (
+            "Represents a single database query made to a Django managed DB."
+        )
+
+    vendor = String(
+        required=True,
+        description=(
+            "The type of database being used (e.g. postrgesql, mysql, sqlite)."
+        ),
+    )
+    alias = String(
+        required=True,
+        description="The Django database alias (e.g. 'default').",
+    )
+    sql = String(description="The actual SQL sent to this database.")
+    duration = Float(
+        required=True,
+        description="Duration of this database query in seconds.",
+    )
+    raw_sql = String(
+        required=True,
+        description="The raw SQL of this query, without params.",
+    )
+    params = String(
+        required=True,
+        description="JSON encoded database query parameters.",
+    )
+    start_time = Float(
+        required=True,
+        description="Start time of this database query.",
+    )
+    stop_time = Float(
+        required=True,
+        description="Stop time of this database query.",
+    )
+    is_slow = Boolean(
+        required=True,
+        description="Whether this database query took more than 10 seconds.",
+    )
+    is_select = Boolean(
+        required=True,
+        description="Whether this database query was a SELECT.",
+    )
 
     # Postgres
-    trans_id = String()
-    trans_status = String()
-    iso_level = String()
-    encoding = String()
+    trans_id = String(description="Postgres transaction ID if available.")
+    trans_status = String(description="Postgres transaction status if available.")
+    iso_level = String(description="Postgres isolation level if available.")
+    encoding = String(description="Postgres connection encoding if available.")

--- a/graphene_django/debug/types.py
+++ b/graphene_django/debug/types.py
@@ -4,4 +4,10 @@ from .sql.types import DjangoDebugSQL
 
 
 class DjangoDebug(ObjectType):
-    sql = List(DjangoDebugSQL)
+    class Meta:
+        description = "Debugging information for the current query."
+
+    sql = List(
+        DjangoDebugSQL,
+        description="Executed SQL queries for this API query.",
+    )


### PR DESCRIPTION
This adds documentation for the debug fields/types in Graphene-Django.

Included in this is more strictness in whether some of the fields are required, as that is an important form of documentation in itself. These were determined from reading the source for `NormalCursorWrapper._record`, and some of the Django functions/methods that back that, but please do review as I might have missed something.