### PR TITLE
Get queryset

### DIFF
--- a/docs/authorization.rst
+++ b/docs/authorization.rst
@@ -96,6 +96,29 @@ schema is simple.
 
     result = schema.execute(query, context_value=request)
 
+
+Global Filtering
+----------------
+
+If you are using ``DjangoObjectType`` you can define a custom `get_queryset`.
+
+.. code:: python
+
+    from graphene import relay
+    from graphene_django.types import DjangoObjectType
+    from .models import Post
+
+    class PostNode(DjangoObjectType):
+        class Meta:
+            model = Post
+
+        @classmethod
+        def get_queryset(cls, queryset, info):
+            if info.context.user.is_anonymous:
+                return queryset.filter(published=True)
+            return queryset
+
+
 Filtering ID-based Node Access
 ------------------------------
 

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -66,7 +66,7 @@ class DjangoConnectionField(ConnectionField):
             return getattr(self.model, self.on)
         else:
             return self.model._default_manager
-    
+
     @classmethod
     def resolve_queryset(cls, connection, queryset, info, args):
         return connection._meta.node.get_queryset(queryset, info)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -135,7 +135,8 @@ class DjangoConnectionField(ConnectionField):
                 args["last"] = min(last, max_limit)
 
         iterable = resolver(root, info, **args)
-        on_resolve = partial(cls.resolve_connection, connection, default_manager, args)
+        queryset = connection._meta.node.get_queryset(info)
+        on_resolve = partial(cls.resolve_connection, connection, queryset, args)
 
         if Promise.is_thenable(iterable):
             return Promise.resolve(iterable).then(on_resolve)

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -1007,3 +1007,47 @@ def test_proxy_model_fails():
 
     result = schema.execute(query)
     assert result.errors
+
+
+def test_should_resolve_get_queryset_connectionfields():
+    reporter_1 = Reporter.objects.create(
+        first_name="John", last_name="Doe", email="johndoe@example.com", a_choice=1
+    )
+    reporter_2 = CNNReporter.objects.create(
+        first_name="Some",
+        last_name="Guy",
+        email="someguy@cnn.com",
+        a_choice=1,
+        reporter_type=2,  # set this guy to be CNN
+    )
+
+    class ReporterType(DjangoObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node,)
+
+        @classmethod
+        def get_queryset(cls, queryset, info):
+            return queryset.filter(reporter_type=2)
+
+    class Query(graphene.ObjectType):
+        all_reporters = DjangoConnectionField(ReporterType)
+
+    schema = graphene.Schema(query=Query)
+    query = """
+        query ReporterPromiseConnectionQuery {
+            allReporters(first: 1) {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
+        }
+    """
+
+    expected = {"allReporters": {"edges": [{"node": {"id": "UmVwb3J0ZXJUeXBlOjI="}}]}}
+
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data == expected

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -126,7 +126,7 @@ class DjangoObjectType(ObjectType):
 
         model = root._meta.model._meta.concrete_model
         return model == cls._meta.model
-    
+
     @classmethod
     def get_queryset(cls, queryset, info):
         return queryset

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -126,10 +126,14 @@ class DjangoObjectType(ObjectType):
 
         model = root._meta.model._meta.concrete_model
         return model == cls._meta.model
+    
+    @classmethod
+    def get_queryset(cls, info):
+        return cls._meta.model.objects
 
     @classmethod
     def get_node(cls, info, id):
         try:
-            return cls._meta.model.objects.get(pk=id)
+            return cls.get_queryset(info).get(pk=id)
         except cls._meta.model.DoesNotExist:
             return None

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -128,12 +128,13 @@ class DjangoObjectType(ObjectType):
         return model == cls._meta.model
     
     @classmethod
-    def get_queryset(cls, info):
-        return cls._meta.model.objects
+    def get_queryset(cls, queryset, info):
+        return queryset
 
     @classmethod
     def get_node(cls, info, id):
+        queryset = cls.get_queryset(cls._meta.model.objects, info)
         try:
-            return cls.get_queryset(info).get(pk=id)
+            return queryset.get(pk=id)
         except cls._meta.model.DoesNotExist:
             return None


### PR DESCRIPTION
My attempt at adding support for `DjangoObjectType.get_queryset` as described as Option 1 for #79 ; Tried to match up the method call as much as possible but dropped `request` and `args` as I wanted `get_node` to also be able to call `get_queryset` . 