### PR TITLE
Document how custom error formatting works

### DIFF
--- a/docs/custom-errors.rst
+++ b/docs/custom-errors.rst
@@ -1,0 +1,51 @@
+Custom errors
+=============
+
+Default GraphQL error format similar to the following snippet
+
+.. code: json
+
+    {
+      "errors": [
+        {
+          "message": "Variable \"$myAwesomeField\" of required type \"String!\" was not provided.",
+          "locations": [
+            {
+              "line": 1,
+              "column": 13
+            }
+          ]
+        }
+      ]
+    }
+
+And there is a way customise it by swapping default ``GraphQLView`` with your own
+and then override ``format_error`` method
+
+.. code: python
+    class MyGraphQLView(GraphQLView):
+        @staticmethod
+        def format_error(error) -> Dict[str, Any]:
+            if isinstance(error, GraphQLError):
+                return format_error(error)
+
+            return GraphQLView.format_error(error)
+
+
+Here is custom formatting function
+
+.. code: python
+  def format_error(error: GraphQLError) -> Dict[str, Any]:
+      """Extract field from ``error`` and return formatted error
+      :param error: GraphQLError
+      :return: mapping of fieldName -> error message
+      """
+      formatted_error = {
+          n.variable.name.value: str(error)
+          for n in error.nodes
+      }
+
+      if error.path:
+          formatted_error["path"] = error.path
+
+      return formatted_error

--- a/docs/custom-errors.rst
+++ b/docs/custom-errors.rst
@@ -51,3 +51,7 @@ Here is custom formatting function
           formatted_error["path"] = error.path
 
       return formatted_error
+
+
+.. note::
+  ``error.nodes`` might be other GraphQL type as well.

--- a/docs/custom-errors.rst
+++ b/docs/custom-errors.rst
@@ -3,7 +3,7 @@ Custom errors
 
 Default GraphQL error format similar to the following snippet
 
-.. code: json
+.. code:: json
 
     {
       "errors": [
@@ -22,7 +22,8 @@ Default GraphQL error format similar to the following snippet
 And there is a way customise it by swapping default ``GraphQLView`` with your own
 and then override ``format_error`` method
 
-.. code: python
+.. code:: python
+
     class MyGraphQLView(GraphQLView):
         @staticmethod
         def format_error(error) -> Dict[str, Any]:
@@ -34,7 +35,8 @@ and then override ``format_error`` method
 
 Here is custom formatting function
 
-.. code: python
+.. code:: python
+
   def format_error(error: GraphQLError) -> Dict[str, Any]:
       """Extract field from ``error`` and return formatted error
       :param error: GraphQLError

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,4 +13,4 @@ Contents:
    debug
    rest-framework
    form-mutations
-   introspection
+   custom-errors


### PR DESCRIPTION
This PR documents how to customise default error formatting by providing

1. Custom `GraphQLView`,
2. Custom error formatter.

Please give your feedback on what needs to be adjusted and/or added.