### PR TITLE
Make django connections nonnull unless enforce first or last

### DIFF
--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -110,7 +110,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         return partial(
             self.connection_resolver,
             parent_resolver,
-            self.type,
+            self.connection_type,
             self.get_manager(),
             self.max_limit,
             self.enforce_first_or_last,

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -233,7 +233,7 @@ def test_should_manytomany_convert_connectionorlist_connection():
     assert isinstance(graphene_field, graphene.Dynamic)
     dynamic_field = graphene_field.get_type()
     assert isinstance(dynamic_field, ConnectionField)
-    assert dynamic_field.type == A._meta.connection
+    assert dynamic_field.connection_type == A._meta.connection
 
 
 def test_should_manytoone_convert_connectionorlist():

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -638,15 +638,13 @@ def test_should_error_if_last_is_greater_than_max():
         }
     """
 
-    expected = {"allReporters": None}
-
     result = schema.execute(query)
     assert len(result.errors) == 1
     assert str(result.errors[0]) == (
         "Requesting 101 records on the `allReporters` connection "
         "exceeds the `last` limit of 100 records."
     )
-    assert result.data == expected
+    assert result.data == None
 
     graphene_settings.RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST = False
 

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -168,7 +168,7 @@ type Reporter {
   pets: [Reporter]
   aChoice: ReporterAChoice!
   reporterType: ReporterReporterType
-  articles(before: String, after: String, first: Int, last: Int): ArticleConnection
+  articles(before: String, after: String, first: Int, last: Int): ArticleConnection!
 }
 
 enum ReporterAChoice {


### PR DESCRIPTION
https://github.com/graphql-python/graphene-django/issues/566

Less existence checking when generating types