### PR TITLE
Make it easier to define custom filters without django-filter

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -44,7 +44,9 @@ class DjangoConnectionField(ConnectionField):
 
     @property
     def args(self):
-        return to_arguments(self._base_args or OrderedDict(), self.node_type.get_connection_parameters())
+        args = OrderedDict(self._base_args)
+        args.update(self.node_type.get_connection_parameters())
+        return to_arguments(args)
 
     @args.setter
     def args(self, args):

--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -76,17 +76,18 @@ class DjangoFilterConnectionField(DjangoConnectionField):
 
     @classmethod
     def connection_resolver(
-        cls,
-        resolver,
-        connection,
-        default_manager,
-        max_limit,
-        enforce_first_or_last,
-        filterset_class,
-        filtering_args,
-        root,
-        info,
-        **args
+            cls,
+            resolver,
+            connection,
+            node,
+            default_manager,
+            max_limit,
+            enforce_first_or_last,
+            filterset_class,
+            filtering_args,
+            root,
+            info,
+            **args
     ):
         filter_kwargs = {k: v for k, v in args.items() if k in filtering_args}
         qs = filterset_class(
@@ -98,6 +99,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         return super(DjangoFilterConnectionField, cls).connection_resolver(
             resolver,
             connection,
+            node,
             qs,
             max_limit,
             enforce_first_or_last,
@@ -111,6 +113,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
             self.connection_resolver,
             parent_resolver,
             self.type,
+            self.node_type,
             self.get_manager(),
             self.max_limit,
             self.enforce_first_or_last,

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -111,6 +111,14 @@ class DjangoObjectType(ObjectType):
         if not skip_registry:
             registry.register(cls)
 
+    @classmethod
+    def refine_queryset(cls, qs, info, **kwargs):
+        return qs
+
+    @classmethod
+    def get_connection_parameters(cls):
+        return {}
+
     def resolve_id(self, info):
         return self.pk
 
@@ -130,6 +138,6 @@ class DjangoObjectType(ObjectType):
     @classmethod
     def get_node(cls, info, id):
         try:
-            return cls._meta.model.objects.get(pk=id)
+            return cls.refine_queryset(cls._meta.model.objects, info).get(pk=id)
         except cls._meta.model.DoesNotExist:
             return None


### PR DESCRIPTION
`refine_queryset` lets `DjangoObjectType` define exactly how the queryset should be refined before being returned to the user. For instance, some objects could be filtered out according to a predicate, or some fields could be prefetched depending on what the initial query requested.

`get_connection_parameters` lets `DjangoObjectType` define the name and value of parameters that can be passed to any `DjangoConnectionField` that uses them.

Both these additions come as building blocks to allow custom refinements and filters without having to go through django-filter. Moreover, such filters can also be further optimized than previously allowed, as the GraphQL ResolveInfo instance is available in `refine_queryset`.

Example usage:

```python
class RecipeOrderBy(graphene.Enum):
    name__ASC = 'name'
    name__DESC = '-name'

class RecipeNode(DjangoObjectType):
    class Meta:
        model = Recipe
        interfaces = (graphene.relay.Node,)

    @classmethod
    def get_connection_parameters(cls):
        return {
            'order_by': RecipeOrderBy()
        }

    @classmethod
    def refine_queryset(cls, qs, info, **kwargs):
        if 'order_by' in kwargs:
            qs = qs.order_by(RecipeOrderBy.get(kwargs['order_by']).value)
        # Since we have access to the GraphQL query's ResolveInfo instance through the info
        # argument, you can enable some prefetch optimizations here as well.
        return qs
```