### PR TITLE
Make CSRF cookie and header names configuration based on django settings

### DIFF
--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -26,7 +26,7 @@ add "&raw" to the end of the URL within a browser.
   <script>
     // Parse the cookie value for a CSRF token
     var csrftoken;
-    var cookies = ('; ' + document.cookie).split('; csrftoken=');
+    var cookies = ('; ' + document.cookie).split('; {{ csrf_cookie }}=');
     if (cookies.length == 2)
       csrftoken = cookies.pop().split(';').shift();
 
@@ -66,7 +66,7 @@ add "&raw" to the end of the URL within a browser.
         'Content-Type': 'application/json'
       };
       if (csrftoken) {
-        headers['X-CSRFToken'] = csrftoken;
+        headers['{{csrf_header}}'] = csrftoken;
       }
       return fetch(fetchURL, {
         method: 'post',

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -3,16 +3,16 @@ import json
 import re
 
 import six
+from django.conf import settings
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.http.response import HttpResponseBadRequest
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from django.views.generic import View
 from django.views.decorators.csrf import ensure_csrf_cookie
-
+from django.views.generic import View
 from graphql import get_default_backend
-from graphql.error import format_error as format_graphql_error
 from graphql.error import GraphQLError
+from graphql.error import format_error as format_graphql_error
 from graphql.execution import ExecutionResult
 from graphql.type.schema import GraphQLSchema
 
@@ -148,6 +148,8 @@ class GraphQLView(View):
                     variables=json.dumps(variables) or "",
                     operation_name=operation_name or "",
                     result=result or "",
+                    csrf_cookie=settings.CSRF_COOKIE_NAME,
+                    csrf_header=self.get_csrf_header_name(settings.CSRF_HEADER_NAME),
                 )
 
             return HttpResponse(
@@ -343,3 +345,11 @@ class GraphQLView(View):
         meta = request.META
         content_type = meta.get("CONTENT_TYPE", meta.get("HTTP_CONTENT_TYPE", ""))
         return content_type.split(";", 1)[0].lower()
+
+    @staticmethod
+    def get_csrf_header_name(django_csrf_header_name):
+        header_name = django_csrf_header_name
+        if header_name.startswith('HTTP_'):
+            header_name = header_name[5:]
+
+        return header_name.replace('_', '-')


### PR DESCRIPTION
**Issue:**

Django allows the the CSRF cookie and header to be configured through the use of settings variables. graphene-django's implementation if GraphIQL does not respect these settings which causes a CSRF failure. 

**Fix:**
This PR fixes the issue by reading the values from the django settings values and uses them in the graphiql template. 

**Repro:**
1. create graphene-django project
2. set django setting CSRF_COOKIE_NAME and CSRF_HEADER_NAME to non standard values
3. Launch graphiql

**Expected:** 
GraphIQL works as expected (request / response pass and scheme can be inspected)

**Actual:**
403 status' are returned due to a CSRF failure

