### PR TITLE
Add default value to generated enum if not included in choices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ Session.vim
 *~
 # auto-generated tag files
 tags
+
+# Pipenv
+Pipfile
+Pipfile.lock

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -62,6 +62,8 @@ def convert_django_field_with_choices(field, registry=None):
         meta = field.model._meta
         name = to_camel_case("{}_{}".format(meta.object_name, field.name))
         choices = list(get_choices(choices))
+        if field.blank:
+            choices.append(('EMPTY', '', ''))
         named_choices = [(c[0], c[1]) for c in choices]
         named_choices_descriptions = {c[0]: c[2] for c in choices}
 

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -62,8 +62,11 @@ def convert_django_field_with_choices(field, registry=None):
         meta = field.model._meta
         name = to_camel_case("{}_{}".format(meta.object_name, field.name))
         choices = list(get_choices(choices))
-        if field.blank:
-            choices.append(('EMPTY', '', ''))
+        default = field.get_default()
+        if default:
+            choices_include_default = bool([choice for choice in field.choices if choice[0] == default])
+            if not choices_include_default:
+                choices.append(('DEFAULT', default, 'default value'))
         named_choices = [(c[0], c[1]) for c in choices]
         named_choices_descriptions = {c[0]: c[2] for c in choices}
 

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -196,9 +196,9 @@ def test_field_with_choices_collision():
     convert_django_field_with_choices(field)
 
 
-def test_field_with_blank():
+def test_field_with_choices_and_default():
     field = models.CharField(
-        help_text="Language", choices=(("es", "Spanish"), ("en", "English")), blank=True
+        help_text="Language", choices=(("es", "Spanish"), ("en", "English")), default="nl"
     )
 
     class TranslatedModel(models.Model):
@@ -208,8 +208,24 @@ def test_field_with_blank():
             app_label = "test"
 
     graphene_type = convert_django_field_with_choices(field)
-    assert graphene_type._meta.enum.__members__["EMPTY"].value == ""
-    assert graphene_type._meta.enum.__members__["EMPTY"].description == ""
+    assert graphene_type._meta.enum.__members__["DEFAULT"].value == "nl"
+    assert graphene_type._meta.enum.__members__["DEFAULT"].description == "default value"
+
+
+def test_field_with_default_in_choices():
+    field = models.CharField(
+        help_text="Language", choices=(("es", "Spanish"), ("en", "English")), default="es"
+    )
+
+    class TranslatedModel(models.Model):
+        language = field
+
+        class Meta:
+            app_label = "test"
+
+    graphene_type = convert_django_field_with_choices(field)
+
+    assert "DEFAULT" not in graphene_type._meta.enum.__members__
 
 
 def test_should_float_convert_float():

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -196,6 +196,22 @@ def test_field_with_choices_collision():
     convert_django_field_with_choices(field)
 
 
+def test_field_with_blank():
+    field = models.CharField(
+        help_text="Language", choices=(("es", "Spanish"), ("en", "English")), blank=True
+    )
+
+    class TranslatedModel(models.Model):
+        language = field
+
+        class Meta:
+            app_label = "test"
+
+    graphene_type = convert_django_field_with_choices(field)
+    assert graphene_type._meta.enum.__members__["EMPTY"].value == ""
+    assert graphene_type._meta.enum.__members__["EMPTY"].description == ""
+
+
 def test_should_float_convert_float():
     assert_conversion(models.FloatField, graphene.Float)
 
@@ -241,7 +257,7 @@ def test_should_manytoone_convert_connectionorlist():
         class Meta:
             model = Article
 
-    graphene_field = convert_django_field(Reporter.articles.rel, 
+    graphene_field = convert_django_field(Reporter.articles.rel,
                                           A._meta.registry)
     assert isinstance(graphene_field, graphene.Dynamic)
     dynamic_field = graphene_field.get_type()

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -138,6 +138,7 @@ type ArticleEdge {
 enum ArticleImportance {
   A_1
   A_2
+  EMPTY
 }
 
 enum ArticleLang {
@@ -179,6 +180,7 @@ enum ReporterAChoice {
 enum ReporterReporterType {
   A_1
   A_2
+  EMPTY
 }
 
 type RootQuery {

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -138,7 +138,6 @@ type ArticleEdge {
 enum ArticleImportance {
   A_1
   A_2
-  EMPTY
 }
 
 enum ArticleLang {
@@ -180,7 +179,6 @@ enum ReporterAChoice {
 enum ReporterReporterType {
   A_1
   A_2
-  EMPTY
 }
 
 type RootQuery {


### PR DESCRIPTION
Closes https://github.com/graphql-python/graphene-django/issues/474

Django fields with `default="something"` may not be included in choices but the value is a valid initial value for the field. This adds an `DEFAULT` option to the enum generated if the default value is not present in the choices.

https://simpleisbetterthancomplex.com/tips/2016/07/25/django-tip-8-blank-or-null.html