### PR TITLE
Add static files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md LICENSE
 recursive-include graphene_django/templates *
+recursive-include graphene_django/static *


### PR DESCRIPTION
At the moment, static files are not included in the package data
when installing using setuptools. This is necessary for the
GraphiQL view.