### PR TITLE
Fix passing required=True to DjangoConnectionField

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -118,15 +118,15 @@ class DjangoConnectionField(ConnectionField):
 
     @classmethod
     def connection_resolver(
-            cls,
-            resolver,
-            connection,
-            default_manager,
-            max_limit,
-            enforce_first_or_last,
-            root,
-            info,
-            **args
+        cls,
+        resolver,
+        connection,
+        default_manager,
+        max_limit,
+        enforce_first_or_last,
+        root,
+        info,
+        **args
     ):
         first = args.get("first")
         last = args.get("last")


### PR DESCRIPTION
Passing `required=True` to an instance of `DjangoConnectionField` currently raises the following exception:

```
  ...
  File "/env/lib/python3.6/site-packages/graphql/type/typemap.py", line 106, in reducer
    field_map = type.fields
  File "/env/lib/python3.6/site-packages/graphql/pyutils/cached_property.py", line 22, in __get__
    value = obj.__dict__[self.func.__name__] = self.func(obj)
  File "/env/lib/python3.6/site-packages/graphql/type/definition.py", line 221, in fields
    return define_field_map(self, self._fields)
  File "/env/lib/python3.6/site-packages/graphql/type/definition.py", line 235, in define_field_map
    field_map = field_map()
  File "/env/lib/python3.6/site-packages/graphene/types/typemap.py", line 274, in construct_fields_for_type
    map = self.reducer(map, field.type)
  File "/env/lib/python3.6/site-packages/graphene-django/graphene_django/fields.py", line 61, in type
    _type, DjangoObjectType
TypeError: issubclass() arg 1 must be a class
```

The reason for the exception is that DjangoConnectionField does not expect its `type` to be wrapped in a `NonNull` instance. This PR ensures that it handles that case properly.