### PR TITLE
Set converted Django connections to required

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -195,9 +195,11 @@ def convert_field_to_list_or_connection(field, registry=None):
             if _type._meta.filter_fields or _type._meta.filterset_class:
                 from .filter.fields import DjangoFilterConnectionField
 
-                return DjangoFilterConnectionField(_type, description=description)
+                return DjangoFilterConnectionField(
+                    _type, required=True, description=description
+                )
 
-            return DjangoConnectionField(_type, description=description)
+            return DjangoConnectionField(_type, required=True, description=description)
 
         return DjangoListField(
             _type,

--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -111,7 +111,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         return partial(
             self.connection_resolver,
             parent_resolver,
-            self.type,
+            self.connection_type,
             self.get_manager(),
             self.max_limit,
             self.enforce_first_or_last,

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -255,7 +255,7 @@ def test_should_manytomany_convert_connectionorlist_connection():
     assert isinstance(graphene_field, graphene.Dynamic)
     dynamic_field = graphene_field.get_type()
     assert isinstance(dynamic_field, ConnectionField)
-    assert dynamic_field.type == A._meta.connection
+    assert dynamic_field.type.of_type == A._meta.connection
 
 
 def test_should_manytoone_convert_connectionorlist():

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -173,7 +173,7 @@ type Reporter {
   pets: [Reporter!]!
   aChoice: ReporterAChoice
   reporterType: ReporterReporterType
-  articles(before: String, after: String, first: Int, last: Int): ArticleConnection
+  articles(before: String, after: String, first: Int, last: Int): ArticleConnection!
 }
 
 enum ReporterAChoice {


### PR DESCRIPTION
I'm not sure why they're currently nullable, since I believe the default resolver implementation isn't.

Depends upon https://github.com/graphql-python/graphene-django/pull/609