### PR TITLE
Convert MultipleChoiceField to List of type String

### DIFF
--- a/docs/filtering.rst
+++ b/docs/filtering.rst
@@ -124,10 +124,14 @@ create your own ``FilterSet``. You can pass it directly as follows:
         # Do case-insensitive lookups on 'name'
         name = django_filters.CharFilter(lookup_expr=['iexact'])
         # Allow multiple genera to be selected at once
-        genera = django_filters.MultipleChoiceFilter(field_name='genus',
-                                                     choices=(('Canis', 'Canis'),
-                                                              ('Panthera', 'Panthera'),
-                                                              ('Seahorse', 'Seahorse')))
+        genera = django_filters.MultipleChoiceFilter(
+            field_name='genus',
+            choices=(
+                ('Canis', 'Canis'),
+                ('Panthera', 'Panthera'),
+                ('Seahorse', 'Seahorse')
+            )
+        )
 
         class Meta:
             model = Animal

--- a/docs/filtering.rst
+++ b/docs/filtering.rst
@@ -123,6 +123,11 @@ create your own ``FilterSet``. You can pass it directly as follows:
     class AnimalFilter(django_filters.FilterSet):
         # Do case-insensitive lookups on 'name'
         name = django_filters.CharFilter(lookup_expr=['iexact'])
+        # Allow multiple genera to be selected at once
+        genera = django_filters.MultipleChoiceFilter(field_name='genus',
+                                                     choices=(('Canis', 'Canis'),
+                                                              ('Panthera', 'Panthera'),
+                                                              ('Seahorse', 'Seahorse')))
 
         class Meta:
             model = Animal
@@ -134,6 +139,22 @@ create your own ``FilterSet``. You can pass it directly as follows:
         # We specify our custom AnimalFilter using the filterset_class param
         all_animals = DjangoFilterConnectionField(AnimalNode,
                                                   filterset_class=AnimalFilter)
+
+
+If you were interested in selecting all dogs and cats, you might query as follows:
+
+.. code::
+
+    query {
+      allAnimals(genera: ["Canis", "Panthera"]) {
+        edges {
+          node {
+            id,
+            name
+          }
+        }
+      }
+    }
 
 You can also specify the ``FilterSet`` class using the ``filterset_class``
 parameter when defining your ``DjangoObjectType``, however, this can't be used
@@ -161,6 +182,7 @@ in unison  with the ``filter_fields`` parameter:
     class Query(ObjectType):
         animal = relay.Node.Field(AnimalNode)
         all_animals = DjangoFilterConnectionField(AnimalNode)
+
 
 The context argument is passed on as the `request argument <http://django-filter.readthedocs.io/en/master/guide/usage.html#request-based-filtering>`__
 in a ``django_filters.FilterSet`` instance. You can use this to customize your

--- a/graphene_django/forms/converter.py
+++ b/graphene_django/forms/converter.py
@@ -55,9 +55,14 @@ def convert_form_field_to_float(field):
     return Float(description=field.help_text, required=field.required)
 
 
+@convert_form_field.register(forms.MultipleChoiceField)
+def convert_form_field_to_string_list(field):
+    return List(String, description=field.help_text, required=field.required)
+
+
 @convert_form_field.register(forms.ModelMultipleChoiceField)
 @convert_form_field.register(GlobalIDMultipleChoiceField)
-def convert_form_field_to_list(field):
+def convert_form_field_to_id_list(field):
     return List(ID, required=field.required)
 
 

--- a/graphene_django/forms/tests/test_converter.py
+++ b/graphene_django/forms/tests/test_converter.py
@@ -66,6 +66,10 @@ def test_should_choice_convert_string():
     assert_conversion(forms.ChoiceField, String)
 
 
+def test_should_multiple_choice_convert_list():
+    assert_conversion(forms.MultipleChoiceField, List)
+
+
 def test_should_base_field_convert_string():
     assert_conversion(forms.Field, String)
 


### PR DESCRIPTION
The django_filters.MultipleChoiceFilter is currently being converted to a String (due to MultipleChoiceFilter eventually inheriting from django.forms.fields.ChoiceField). 

This PR changes that behavior so that it instead gets converted into a List of type String. 