### PR TITLE
Add Makefile and better CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,20 @@ After developing, the full test suite can be evaluated by running:
 ```sh
 make tests
 ```
+
+## Documentation
+
+The [documentation](http://docs.graphene-python.org/projects/django/en/latest/) is generated using the excellent [Sphinx](http://www.sphinx-doc.org/) and a custom theme.
+
+The documentation dependencies are installed by running:
+
+```sh
+cd docs
+pip install -r requirements.txt
+```
+
+Then to produce a HTML version of the documentation:
+
+```sh
+make html
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thanks for helping to make graphene-django great!
+
+We welcome all kinds of contributions:
+
+- Bug fixes
+- Documentation improvements
+- New features
+- Refactoring & tidying
+
+
+## Getting started
+
+If you have a specific contribution in mind, be sure to check the [issues](https://github.com/graphql-python/graphene-django/issues) and [projects](https://github.com/graphql-python/graphene-django/projects) in progress - someone could already be working on something similar and you can help out.
+
+
+## Project setup
+
+After cloning this repo, ensure dependencies are installed by running:
+
+```sh
+make dev-setup
+```
+
+## Running tests
+
+After developing, the full test suite can be evaluated by running:
+
+```sh
+make tests
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+dev-setup:
+	pip install -e ".[test]"
+
+tests:
+	py.test graphene_django --cov=graphene_django -vv

--- a/README.md
+++ b/README.md
@@ -97,21 +97,3 @@ To learn more check out the following [examples](examples/):
 ## Contributing
 
 See [CONTRIBUTING.md](contributing.md)
-
-
-### Documentation
-
-The [documentation](http://docs.graphene-python.org/projects/django/en/latest/) is generated using the excellent [Sphinx](http://www.sphinx-doc.org/) and a custom theme.
-
-The documentation dependencies are installed by running:
-
-```sh
-cd docs
-pip install -r requirements.txt
-```
-
-Then to produce a HTML version of the documentation:
-
-```sh
-make html
-```

--- a/README.md
+++ b/README.md
@@ -96,17 +96,7 @@ To learn more check out the following [examples](examples/):
 
 ## Contributing
 
-After cloning this repo, ensure dependencies are installed by running:
-
-```sh
-pip install -e ".[test]"
-```
-
-After developing, the full test suite can be evaluated by running:
-
-```sh
-py.test graphene_django --cov=graphene_django # Use -v -s for verbose mode
-```
+See [CONTRIBUTING.md](contributing.md)
 
 
 ### Documentation

--- a/README.rst
+++ b/README.rst
@@ -105,17 +105,7 @@ To learn more check out the following `examples <examples/>`__:
 Contributing
 ------------
 
-After cloning this repo, ensure dependencies are installed by running:
-
-.. code:: sh
-
-    pip install -e ".[test]"
-
-After developing, the full test suite can be evaluated by running:
-
-.. code:: sh
-
-    py.test graphene_django --cov=graphene_django # Use -v -s for verbose mode
+See `CONTRIBUTING.md <CONTRIBUTING.md>`__.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -107,25 +107,6 @@ Contributing
 
 See `CONTRIBUTING.md <CONTRIBUTING.md>`__.
 
-Documentation
-~~~~~~~~~~~~~
-
-The `documentation <http://docs.graphene-python.org/projects/django/en/latest/>`__ is generated using the excellent
-`Sphinx <http://www.sphinx-doc.org/>`__ and a custom theme.
-
-The documentation dependencies are installed by running:
-
-.. code:: sh
-
-    cd docs
-    pip install -r requirements.txt
-
-Then to produce a HTML version of the documentation:
-
-.. code:: sh
-
-    make html
-
 .. |Graphene Logo| image:: http://graphene-python.org/favicon.png
 .. |Build Status| image:: https://travis-ci.org/graphql-python/graphene-django.svg?branch=master
    :target: https://travis-ci.org/graphql-python/graphene-django


### PR DESCRIPTION
GitHub will pick up `CONTRIBUTING.md` automatically and point developers to it when they open issues/PRs.
This will also tidy up the main readme, and allow us to extend CONTRIBUTING.md in the future.
I've added a Makefile to the project to wrap up common commands