### PR TITLE
Manage Django choices & Enums with DjangoChoicesEnum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ dev-setup:
 	pip install -e ".[dev]"
 
 tests:
-	py.test graphene_django --cov=graphene_django -vv
+	py.test graphene_django --cov=graphene_django -vv -x
 
 format:
 	black graphene_django

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ For more advanced use, check out the Relay tutorial.
    schema
    queries
    mutations
+   types
    filtering
    authorization
    debug

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -30,7 +30,7 @@ Default: ``None``
 
 
 ``SCHEMA_OUTPUT``
-----------
+-----------------
 
 The name of the file where the GraphQL schema output will go.
 
@@ -44,7 +44,7 @@ Default: ``schema.json``
 
 
 ``SCHEMA_INDENT``
-----------
+-----------------
 
 The indentation level of the schema output.
 
@@ -58,7 +58,7 @@ Default: ``2``
 
 
 ``MIDDLEWARE``
-----------
+--------------
 
 A tuple of middleware that will be executed for each GraphQL query.
 
@@ -76,7 +76,7 @@ Default: ``()``
 
 
 ``RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST``
-----------
+------------------------------------------
 
 Enforces relay queries to have the ``first`` or ``last`` argument.
 
@@ -90,7 +90,7 @@ Default: ``False``
 
 
 ``RELAY_CONNECTION_MAX_LIMIT``
-----------
+------------------------------
 
 The maximum size of objects that can be requested through a relay connection.
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -1,0 +1,84 @@
+Types
+=====
+
+This page documents specific features of Types related to Graphene-Django.
+
+DjangoChoicesEnum
+-----------------
+
+``DjangoChoicesEnum`` is a helper class that lets you keep Graphene style enums
+and ``models.Field.choices`` in sync. Some Django fields accept a ``choices`` list like this:
+
+.. code:: python
+
+    choices = [
+        ('FOO', 'foo'),
+        ('BAR', 'bar'),
+    ]
+
+    class MyModel(models.Model):
+        options = models.CharField(max_length='3', choices=choices)
+
+With Graphene-Django it is useful to represent these choices as an enum:
+
+.. code::
+
+    query getEnumType {
+    __type(name: "MyModelOptions" ) {
+        name
+        enumValues {
+                name
+                description
+            }
+        }
+    }
+
+Which will return a data structure like this:
+
+.. code::
+
+    {
+        "data": {
+            "__type": {
+            "name": "MyModelOptions",
+            "enumValues": [
+                {
+                    "name": "FOO",
+                    "description": "foo"
+                },
+                {
+                    "name": "BAR",
+                    "description": "bar"
+                }
+            ]
+            }
+        }
+    }
+
+We can use ``DjangoChoicesEnum`` to support both of these for us:
+
+.. code:: python
+
+    from graphene_django import DjangoObjectType, DjangoChoicesEnum
+    from django.db import models
+
+    # Declare your DjangoChoicesEnum
+    class MyModelChoices(DjangoChoicesEnum):
+        FOO = 'foo'
+        BAR = 'bar'
+
+    # Your model should use the .choices method
+    class MyModel(models.Model):
+        options = models.CharField(
+            max_length='3',
+            choices=DjangoChoicesEnum.choices(),
+            default=DjangoChoicesEnum.choices()[0][0],
+        )
+
+    # And your ObjectType should explicitly declare the type:
+    class MyModelType(DjangoObjectType):
+        class Meta:
+            model = MyModel
+            fields = ('options',)
+
+        options = MyModelChoices.as_enum()

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -6,6 +6,8 @@ This page documents specific features of Types related to Graphene-Django.
 DjangoChoicesEnum
 -----------------
 
+*Introduced in graphene-django 2.3*
+
 ``DjangoChoicesEnum`` is a helper class that lets you keep Graphene style enums
 and ``models.Field.choices`` in sync. Some Django fields accept a ``choices`` list like this:
 

--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -1,6 +1,11 @@
-from .types import DjangoObjectType
+from .types import DjangoObjectType, DjangoChoicesEnum
 from .fields import DjangoConnectionField
 
 __version__ = "2.2.0"
 
-__all__ = ["__version__", "DjangoObjectType", "DjangoConnectionField"]
+__all__ = [
+    "__version__",
+    "DjangoObjectType",
+    "DjangoConnectionField",
+    "DjangoChoicesEnum",
+]

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -114,8 +114,5 @@ class MyCustomChoices(DjangoChoicesEnum):
 
 class FilmWithChoices(models.Model):
     genre = models.CharField(
-        max_length=2,
-        help_text="Genre",
-        choices=MyCustomChoices.choices(),
-        default=MyCustomChoices.choices()[0][0],
+        max_length=2, help_text="Genre", choices=MyCustomChoices.choices(), default="DO"
     )

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from ..types import DjangoChoicesEnum
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
@@ -103,3 +105,17 @@ class Article(models.Model):
 
     class Meta:
         ordering = ("headline",)
+
+
+class MyCustomChoices(DjangoChoicesEnum):
+    DO = "Documentary"
+    OT = "Other"
+
+
+class FilmWithChoices(models.Model):
+    genre = models.CharField(
+        max_length=2,
+        help_text="Genre",
+        choices=MyCustomChoices.choices(),
+        default=MyCustomChoices.choices()[0][0],
+    )

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -10,10 +10,10 @@ from graphene.types.json import JSONString
 
 from ..compat import JSONField, ArrayField, HStoreField, RangeField, MissingType
 from ..converter import convert_django_field, convert_django_field_with_choices
+from ..settings import graphene_settings
 from ..registry import Registry
 from ..types import DjangoObjectType
 from .models import Article, Film, FilmDetails, Reporter
-
 
 # from graphene.core.types.custom_scalars import DateTime, Time, JSONString
 
@@ -128,10 +128,12 @@ def test_should_nullboolean_convert_boolean():
     assert_conversion(models.NullBooleanField, graphene.Boolean)
 
 
-def test_field_with_choices_convert_enum():
-    field = models.CharField(
-        help_text="Language", choices=(("es", "Spanish"), ("en", "English"))
-    )
+@pytest.mark.parametrize(
+    "choices",
+    ((("es", "Spanish"), ("en", "English")), [("es", "Spanish"), ("en", "English")]),
+)
+def test_field_with_choices_convert_enum(choices):
+    field = models.CharField(help_text="Language", choices=choices)
 
     class TranslatedModel(models.Model):
         language = field

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -1072,7 +1072,7 @@ def test_using_django_choices_enum():
         def resolve_films(self, info, **args):
             return Film.objects.all()
 
-    f = FilmWithChoices.objects.create()
+    f = FilmWithChoices.objects.create(genre="DO")
 
     query = """
         query NodeFilteringQuery {
@@ -1104,7 +1104,8 @@ def test_using_django_choices_enum():
     result = schema.execute(query)
     assert not result.errors
     enum_values = result.data["__type"]["enumValues"]
-    assert enum_values == [
-        {"name": "DO", "description": "Documentary"},
+    for result in [
         {"name": "OT", "description": "Other"},
-    ]
+        {"name": "DO", "description": "Documentary"},
+    ]:
+        assert result in enum_values

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -2,9 +2,10 @@ from mock import patch
 
 from graphene import Interface, ObjectType, Schema, Connection, String
 from graphene.relay import Node
+from graphene.types.enum import Enum, EnumMeta, EnumOptions
 
 from .. import registry
-from ..types import DjangoObjectType, DjangoObjectTypeOptions
+from ..types import DjangoObjectType, DjangoObjectTypeOptions, DjangoChoicesEnum
 from .models import Article as ArticleModel
 from .models import Reporter as ReporterModel
 
@@ -224,3 +225,21 @@ def test_django_objecttype_exclude_fields():
 
     fields = list(Reporter._meta.fields.keys())
     assert "email" not in fields
+
+
+def test_custom_django_choices_enum():
+    class MyChoicesEnum(DjangoChoicesEnum):
+        FOO = "foo"
+        BAR = "bar"
+
+    # As a Graphene enum
+    graphene_enum = MyChoicesEnum.as_enum()
+    assert isinstance(graphene_enum, EnumMeta)
+    assert isinstance(graphene_enum._meta, EnumOptions)
+    assert graphene_enum.FOO.value == "foo"
+    assert graphene_enum.FOO.name == "FOO"
+    assert graphene_enum._meta.name == "MyChoicesEnum"
+    assert graphene_enum._meta.description(graphene_enum.FOO) == "foo"
+
+    # As a Django choices option
+    assert MyChoicesEnum.choices() == [("FOO", "foo"), ("BAR", "bar")]

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -242,4 +242,6 @@ def test_custom_django_choices_enum():
     assert graphene_enum._meta.description(graphene_enum.FOO) == "foo"
 
     # As a Django choices option
-    assert MyChoicesEnum.choices() == [("FOO", "foo"), ("BAR", "bar")]
+    resulting_choices = MyChoicesEnum.choices()
+    for result in (("FOO", "foo"), ("BAR", "bar")):
+        assert result in resulting_choices

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -180,7 +180,7 @@ class DjangoChoicesEnum(object):
         class Model(models.model)
             some_field = CharField(choices=ChoicesType.choices())
         """
-        return [(k, v) for k, v in cls.__dict__.items() if not k.startswith("__")]
+        return tuple((k, v) for k, v in cls.__dict__.items() if not k.startswith("__"))
 
     @classmethod
     def as_enum(cls):

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "Django>=1.11",
         "singledispatch>=3.4.0.3",
         "promise>=2.1",
+        "enum-compat",
     ],
     setup_requires=["pytest-runner"],
     tests_require=tests_require,


### PR DESCRIPTION
This PR aims to resolve some of the issues seen with choices and enums:

-  #133
- #280
- #577
- #193 
- #240 
- #471 
- #505
- #225
- #517 

They all want different things, so there isn't going to be a solution that makes everyone happy. This PR proposes a solution that covers most of the complaints.

## Major issue 1
### Managing the difference between an enum and a choice list.

Django's choices accept a list of tuples. Graphene's enums don't support this. How can we find a happy medium?

Solution: Implement a helper class that manages the conversion for us.

```python
from graphene_django import DjangoChoicesEnum

class MyChoices(DjangoChoicesEnum):
    FOO = 'foo'
    BAR = 'bar'

# Get a Django choices list
MyChoices.choices()

# Get a Graphene enum
MyChoices.enum()
```

## Major issue 2
### How do I see my enums?

We've documented a way of accessing enums through the API, in the documentation.