### PR TITLE
Fix importing error for GraphQLTestCase

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -9,7 +9,7 @@ Usage:
 
     import json
 
-    from graphene_django.tests.base_test import GraphQLTestCase
+    from graphene_django.utils.testing import GraphQLTestCase
     from my_project.config.schema import schema
 
     class MyFancyTestCase(GraphQLTestCase):

--- a/graphene_django/utils/__init__.py
+++ b/graphene_django/utils/__init__.py
@@ -1,0 +1,19 @@
+from .utils import (
+    DJANGO_FILTER_INSTALLED,
+    get_reverse_fields,
+    maybe_queryset,
+    get_model_fields,
+    is_valid_django_model,
+    import_single_dispatch,
+)
+from .testing import GraphQLTestCase
+
+__all__ = [
+    "DJANGO_FILTER_INSTALLED",
+    "get_reverse_fields",
+    "maybe_queryset",
+    "get_model_fields",
+    "is_valid_django_model",
+    "import_single_dispatch",
+    "GraphQLTestCase",
+]

--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -1,8 +1,6 @@
 import json
 
-from django.http import HttpResponse
-from django.test import Client
-from django.test import TestCase
+from django.test import TestCase, Client
 
 
 class GraphQLTestCase(TestCase):

--- a/graphene_django/utils/utils.py
+++ b/graphene_django/utils/utils.py
@@ -4,13 +4,6 @@ from django.db import models
 from django.db.models.manager import Manager
 
 
-# from graphene.utils import LazyList
-
-
-class LazyList(object):
-    pass
-
-
 try:
     import django_filters  # noqa
 


### PR DESCRIPTION
As mentioned in #628 you cannot import `GraphQLTestCase`, this is because the directory is [excluded when published](https://github.com/graphql-python/graphene-django/blob/master/setup.py#L55).

The best solution is to move this under `utils` and change the import. It's broken anyway.

Fixes #628 