### PR TITLE
Update install docs for Django 2.x

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,16 +30,16 @@ Add ``graphene_django`` to the ``INSTALLED_APPS`` in the ``settings.py`` file of
     ]
 
 
-We need to add a graphql URL to the ``urls.py`` of your Django project:
+We need to add a ``graphql`` URL to the ``urls.py`` of your Django project:
 
 .. code:: python
 
-    from django.conf.urls import url
+    from django.urls import path
     from graphene_django.views import GraphQLView
 
     urlpatterns = [
         # ...
-        url(r'^graphql$', GraphQLView.as_view(graphiql=True)),
+        path("graphql", GraphQLView.as_view(graphiql=True)),
     ]
 
 (Change ``graphiql=True`` to ``graphiql=False`` if you do not want to use the GraphiQL API browser.)


### PR DESCRIPTION
This uses the new URL routing syntax with `path()` introduced in Django 2.0 (https://docs.djangoproject.com/en/2.2/releases/2.0/#simplified-url-routing-syntax).  The older `url()` syntax will deprecated at [some point in future](https://docs.djangoproject.com/en/2.2/ref/urls/#url).