### PR TITLE
Correct Babel Relay Plugin docs link per Issue 358.

### DIFF
--- a/docs/introspection.rst
+++ b/docs/introspection.rst
@@ -1,9 +1,7 @@
 Introspection Schema
 ====================
 
-Relay uses `Babel Relay
-Plugin <https://facebook.github.io/relay/docs/guides-babel-plugin.html>`__
-that requires you to provide your GraphQL schema data.
+Relay Modern uses `Babel Relay Plugin <https://facebook.github.io/relay/docs/en/installation-and-setup>`__ which requires you to provide your GraphQL schema data.
 
 Graphene comes with a Django management command to dump your schema
 data to ``schema.json`` which is compatible with babel-relay-plugin.


### PR DESCRIPTION
See graphql-python#358.