### PR TITLE
bump graphiql to 0.13.0, and rename __debug to _debug

### DIFF
--- a/docs/debug.rst
+++ b/docs/debug.rst
@@ -15,7 +15,7 @@ For use the Django Debug plugin in Graphene:
 
 * Add ``graphene_django.debug.DjangoDebugMiddleware`` into ``MIDDLEWARE`` in the ``GRAPHENE`` settings.
 
-* Add the ``debug`` field into the schema root ``Query`` with the value ``graphene.Field(DjangoDebug, name='__debug')``.
+* Add the ``debug`` field into the schema root ``Query`` with the value ``graphene.Field(DjangoDebug, name='_debug')``.
 
 
 .. code:: python
@@ -24,7 +24,7 @@ For use the Django Debug plugin in Graphene:
 
     class Query(graphene.ObjectType):
         # ...
-        debug = graphene.Field(DjangoDebug, name='__debug')
+        debug = graphene.Field(DjangoDebug, name='_debug')
 
     schema = graphene.Schema(query=Query)
 
@@ -59,11 +59,11 @@ the GraphQL request, like:
         }
       }
       # Here is the debug field that will output the SQL queries
-      __debug {
+      _debug {
         sql {
           rawSql
         }
       }
     }
 
-Note that the ``__debug`` field must be the last field in your query.
+Note that the ``_debug`` field must be the last field in your query.

--- a/examples/cookbook-plain/cookbook/schema.py
+++ b/examples/cookbook-plain/cookbook/schema.py
@@ -8,7 +8,7 @@ from graphene_django.debug import DjangoDebug
 class Query(cookbook.ingredients.schema.Query,
             cookbook.recipes.schema.Query,
             graphene.ObjectType):
-    debug = graphene.Field(DjangoDebug, name='__debug')
+    debug = graphene.Field(DjangoDebug, name='_debug')
 
 
 schema = graphene.Schema(query=Query)

--- a/examples/cookbook/cookbook/schema.py
+++ b/examples/cookbook/cookbook/schema.py
@@ -8,7 +8,7 @@ from graphene_django.debug import DjangoDebug
 class Query(cookbook.ingredients.schema.Query,
             cookbook.recipes.schema.Query,
             graphene.ObjectType):
-    debug = graphene.Field(DjangoDebug, name='__debug')
+    debug = graphene.Field(DjangoDebug, name='_debug')
 
 
 schema = graphene.Schema(query=Query)

--- a/graphene_django/debug/tests/test_query.py
+++ b/graphene_django/debug/tests/test_query.py
@@ -31,7 +31,7 @@ def test_should_query_field():
 
     class Query(graphene.ObjectType):
         reporter = graphene.Field(ReporterType)
-        debug = graphene.Field(DjangoDebug, name="__debug")
+        debug = graphene.Field(DjangoDebug, name="_debug")
 
         def resolve_reporter(self, info, **args):
             return Reporter.objects.first()
@@ -41,7 +41,7 @@ def test_should_query_field():
           reporter {
             lastName
           }
-          __debug {
+          _debug {
             sql {
               rawSql
             }
@@ -50,7 +50,7 @@ def test_should_query_field():
     """
     expected = {
         "reporter": {"lastName": "ABA"},
-        "__debug": {
+        "_debug": {
             "sql": [{"rawSql": str(Reporter.objects.order_by("pk")[:1].query)}]
         },
     }
@@ -75,7 +75,7 @@ def test_should_query_list():
 
     class Query(graphene.ObjectType):
         all_reporters = graphene.List(ReporterType)
-        debug = graphene.Field(DjangoDebug, name="__debug")
+        debug = graphene.Field(DjangoDebug, name="_debug")
 
         def resolve_all_reporters(self, info, **args):
             return Reporter.objects.all()
@@ -85,7 +85,7 @@ def test_should_query_list():
           allReporters {
             lastName
           }
-          __debug {
+          _debug {
             sql {
               rawSql
             }
@@ -94,7 +94,7 @@ def test_should_query_list():
     """
     expected = {
         "allReporters": [{"lastName": "ABA"}, {"lastName": "Griffin"}],
-        "__debug": {"sql": [{"rawSql": str(Reporter.objects.all().query)}]},
+        "_debug": {"sql": [{"rawSql": str(Reporter.objects.all().query)}]},
     }
     schema = graphene.Schema(query=Query)
     result = schema.execute(
@@ -117,7 +117,7 @@ def test_should_query_connection():
 
     class Query(graphene.ObjectType):
         all_reporters = DjangoConnectionField(ReporterType)
-        debug = graphene.Field(DjangoDebug, name="__debug")
+        debug = graphene.Field(DjangoDebug, name="_debug")
 
         def resolve_all_reporters(self, info, **args):
             return Reporter.objects.all()
@@ -131,7 +131,7 @@ def test_should_query_connection():
               }
             }
           }
-          __debug {
+          _debug {
             sql {
               rawSql
             }
@@ -145,9 +145,9 @@ def test_should_query_connection():
     )
     assert not result.errors
     assert result.data["allReporters"] == expected["allReporters"]
-    assert "COUNT" in result.data["__debug"]["sql"][0]["rawSql"]
+    assert "COUNT" in result.data["_debug"]["sql"][0]["rawSql"]
     query = str(Reporter.objects.all()[:1].query)
-    assert result.data["__debug"]["sql"][1]["rawSql"] == query
+    assert result.data["_debug"]["sql"][1]["rawSql"] == query
 
 
 def test_should_query_connectionfilter():
@@ -166,7 +166,7 @@ def test_should_query_connectionfilter():
     class Query(graphene.ObjectType):
         all_reporters = DjangoFilterConnectionField(ReporterType, fields=["last_name"])
         s = graphene.String(resolver=lambda *_: "S")
-        debug = graphene.Field(DjangoDebug, name="__debug")
+        debug = graphene.Field(DjangoDebug, name="_debug")
 
         def resolve_all_reporters(self, info, **args):
             return Reporter.objects.all()
@@ -180,7 +180,7 @@ def test_should_query_connectionfilter():
               }
             }
           }
-          __debug {
+          _debug {
             sql {
               rawSql
             }
@@ -194,6 +194,6 @@ def test_should_query_connectionfilter():
     )
     assert not result.errors
     assert result.data["allReporters"] == expected["allReporters"]
-    assert "COUNT" in result.data["__debug"]["sql"][0]["rawSql"]
+    assert "COUNT" in result.data["_debug"]["sql"][0]["rawSql"]
     query = str(Reporter.objects.all()[:1].query)
-    assert result.data["__debug"]["sql"][1]["rawSql"] == query
+    assert result.data["_debug"]["sql"][1]["rawSql"] == query

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -51,7 +51,7 @@ def instantiate_middleware(middlewares):
 
 
 class GraphQLView(View):
-    graphiql_version = "0.11.11"
+    graphiql_version = "0.13.0"
     graphiql_template = "graphene/graphiql.html"
 
     schema = None


### PR DESCRIPTION
This PR bumps graphiql to 0.13.0, the latest version available on JS CDN, and includes many improvements. And since 0.12 GraphQL prohibits to use names that starts with __, so renamed __debug to _debug. It works for me.

I use graphene-django from master.

fixes https://github.com/graphql-python/graphene-django/issues/640