### PR TITLE
bump react to 16.8.6

### DIFF
--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -23,11 +23,9 @@ add "&raw" to the end of the URL within a browser.
   <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@2.0.3/fetch.min.js"
           integrity="sha384-dcF7KoWRaRpjcNbVPUFgatYgAijf8DqW6NWuqLdfB5Sb4Cdbb8iHX7bHsl9YhpKa"
           crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/react@16.2.0/umd/react.production.min.js"
-          integrity="sha384-j40ChW3xknV2Dsc9+kP3/6SW2UrR7gYSbx9pmyNU1YTacm/PEj/0bxB9vM8jWFqx"
+  <script src="https://cdn.jsdelivr.net/npm/react@{{react_version}}/umd/react.production.min.js"
           crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/react-dom@16.2.0/umd/react-dom.production.min.js"
-          integrity="sha384-P4XM5fEtXj1kXZzsm1EOHZ7HmQIuzyRjjvX4na21R4eRLjmm+oUZua5ALb2PIojw"
+  <script src="https://cdn.jsdelivr.net/npm/react-dom@{{react_version}}/umd/react-dom.production.min.js"
           crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/graphiql@{{graphiql_version}}/graphiql.min.js"
           crossorigin="anonymous"></script>

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -53,6 +53,7 @@ def instantiate_middleware(middlewares):
 class GraphQLView(View):
     graphiql_version = "0.11.10"
     graphiql_template = "graphene/graphiql.html"
+    react_version = "16.8.6"
 
     schema = None
     graphiql = False
@@ -126,7 +127,9 @@ class GraphQLView(View):
 
             if show_graphiql:
                 return self.render_graphiql(
-                    request, graphiql_version=self.graphiql_version
+                    request,
+                    graphiql_version=self.graphiql_version,
+                    react_version=self.react_version,
                 )
 
             if self.batch:


### PR DESCRIPTION
Bump React version to 16.8.6. I checked changes in React and GraphQL-JS, GraphiQL for breaking changes, and didn't found anything.

It works for me.