### PR TITLE
django 1.11.19 is not available, probably for security reasons

### DIFF
--- a/examples/cookbook/requirements.txt
+++ b/examples/cookbook/requirements.txt
@@ -1,5 +1,5 @@
 graphene
 graphene-django
 graphql-core>=2.1rc1
-django==1.11.19
+django==1.11.20
 django-filter>=2


### PR DESCRIPTION
Fix #651 