### PR TITLE
A Slightly smarter enum conversion

### DIFF
--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -1,6 +1,6 @@
 from .types import DjangoObjectType
 from .fields import DjangoConnectionField
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 __all__ = ["__version__", "DjangoObjectType", "DjangoConnectionField"]

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -38,16 +38,19 @@ def convert_choice_name(name):
 
 
 def get_choices(choices):
-    converted_names = []
+    converted_names = set()
     for value, help_text in choices:
         if isinstance(help_text, (tuple, list)):
             for choice in get_choices(help_text):
                 yield choice
         else:
-            name = convert_choice_name(value)
+            if isinstance(value, str):
+                name = convert_choice_name(value)
+            else:
+                name = convert_choice_name(help_text)
             while name in converted_names:
                 name += "_" + str(len(converted_names))
-            converted_names.append(name)
+            converted_names.add(name)
             description = help_text
             yield name, value, description
 

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -31,6 +31,8 @@ singledispatch = import_single_dispatch()
 def convert_choice_name(name):
     name = force_text(name).encode('utf8').decode('ascii', 'ignore')
     name = to_const(name)
+    if name.startswith('_'):
+        name = "A%s" % name
     try:
         assert_valid_name(name)
     except AssertionError:

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -29,7 +29,8 @@ singledispatch = import_single_dispatch()
 
 
 def convert_choice_name(name):
-    name = to_const(force_text(name))
+    name = force_text(name).encode('utf8').decode('ascii', 'ignore')
+    name = to_const(name)
     try:
         assert_valid_name(name)
     except AssertionError:

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 from django.db import models

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, "this"), (2, _("that")))
+CHOICES = ((1, "1: this"), (2, _("2: that")))
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, "1: this漢"), (2, _("2: that漢")))
+CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")))
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")))
+CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")), (3, "__amount__"))
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, "1: this"), (2, _("2: that")))
+CHOICES = ((1, "1: this漢"), (2, _("2: that漢")))
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -177,6 +177,25 @@ def test_field_with_choices_gettext():
     convert_django_field_with_choices(field)
 
 
+def test_field_with_integer_choices():
+    field = models.IntegerField(
+        help_text="Language", choices=((1, "Spanish"), (2, "English"))
+    )
+
+    class TranslatedChoicesModel(models.Model):
+        language = field
+
+        class Meta:
+            app_label = "test"
+
+    graphene_type = convert_django_field_with_choices(field)
+    #assert False, str(graphene_type._meta.enum.__members__)
+    assert graphene_type._meta.enum.__members__["SPANISH"].value == 1
+    assert graphene_type._meta.enum.__members__["SPANISH"].description == "Spanish"
+    assert graphene_type._meta.enum.__members__["ENGLISH"].value == 2
+    assert graphene_type._meta.enum.__members__["ENGLISH"].description == "English"
+
+
 def test_field_with_choices_collision():
     field = models.CharField(
         help_text="Timezone",

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -215,6 +215,24 @@ def test_field_with_choices_collision():
     convert_django_field_with_choices(field)
 
 
+def test_field_with_choices_underscore():
+    field = models.CharField(
+        choices=(
+            ("__amount__", "Amount"),
+            ("__percentage__", "Percentage"),
+        ),
+    )
+
+    class UnderscoreChoicesModel(models.Model):
+        ourfield = field
+
+        class Meta:
+            app_label = "test"
+
+    graphene_type = convert_django_field_with_choices(field)
+    assert len(graphene_type._meta.enum.__members__) == 2
+
+
 def test_should_float_convert_float():
     assert_conversion(models.FloatField, graphene.Float)
 

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -172,8 +172,8 @@ type Reporter {
 }
 
 enum ReporterAChoice {
-  THIS
-  THAT
+  A_1_THIS
+  A_2_THAT
 }
 
 enum ReporterReporterType {

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -174,6 +174,7 @@ type Reporter {
 enum ReporterAChoice {
   A_1_THIS
   A_2_THAT
+  A__AMOUNT__
 }
 
 enum ReporterReporterType {

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -136,8 +136,8 @@ type ArticleEdge {
 }
 
 enum ArticleImportance {
-  A_1
-  A_2
+  VERY_IMPORTANT
+  NOT_AS_IMPORTANT
 }
 
 enum ArticleLang {
@@ -172,13 +172,13 @@ type Reporter {
 }
 
 enum ReporterAChoice {
-  A_1
-  A_2
+  THIS
+  THAT
 }
 
 enum ReporterReporterType {
-  A_1
-  A_2
+  REGULAR
+  CNN_REPORTER
 }
 
 type RootQuery {


### PR DESCRIPTION
Tweaks the enum generator for the django model field converter. When generating an enum name, if the choice value is not a string then use the choice label instead. The result is smarter enum labels for integer fields. Check out the changes in unit testing as an example of better usage.

Not backwards compatible.

Partially addresses #649