### PR TITLE
Update mutations.rst

### DIFF
--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -214,7 +214,7 @@ You can use relay with mutations. A Relay mutation must inherit from
 
         @classmethod
         def mutate_and_get_payload(cls, root, info, text, id):
-            question = Question.objects.get(pk=from_global_id(id))
+            question = Question.objects.get(pk=from_global_id(id)[1])
             question.text = text
             question.save()
             return QuestionMutation(question=question)

--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -199,7 +199,9 @@ You can use relay with mutations. A Relay mutation must inherit from
 
 .. code:: python
 
-    import graphene import relay, DjangoObjectType
+    import graphene 
+    from graphene import relay
+    from graphene_django import DjangoObjectType
     from graphql_relay import from_global_id
 
     from .queries import QuestionType


### PR DESCRIPTION
I believe the `[1]` was ommitted from the `from_global_id` call as that method returns a tuple of type and id, of which we're only interested in the id here. Took me half a day to figure out why this code wasn't working today. See function def here: https://github.com/graphql-python/graphql-relay-py/blob/master/graphql_relay/node/node.py#L67