### PR TITLE
Stop enforcing csrf checks in GraphQLTestCase

### DIFF
--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -22,7 +22,7 @@ class GraphQLTestCase(TestCase):
                 "Variable GRAPHQL_SCHEMA not defined in GraphQLTestCase."
             )
 
-        cls._client = Client(cls.GRAPHQL_SCHEMA)
+        cls._client = Client()
 
     def query(self, query, op_name=None, input_data=None):
         """


### PR DESCRIPTION
Not sure what the purpose of that argument to the class instantiation was, maybe it was an artifact from when a wrapper class was called around the Client? But it acts as the `enforce_csrf_checks` argument which was botching up my tests (I copy pasted the class into my own project until you publish 2.3.0)