### PR TITLE
Fix o2o relation

### DIFF
--- a/graphene_django/debug/tests/test_query.py
+++ b/graphene_django/debug/tests/test_query.py
@@ -50,9 +50,7 @@ def test_should_query_field():
     """
     expected = {
         "reporter": {"lastName": "ABA"},
-        "_debug": {
-            "sql": [{"rawSql": str(Reporter.objects.order_by("pk")[:1].query)}]
-        },
+        "_debug": {"sql": [{"rawSql": str(Reporter.objects.order_by("pk")[:1].query)}]},
     }
     schema = graphene.Schema(query=Query)
     result = schema.execute(

--- a/graphene_django/utils/utils.py
+++ b/graphene_django/utils/utils.py
@@ -18,7 +18,7 @@ def get_reverse_fields(model, local_field_names):
         if name in local_field_names:
             continue
 
-        # Django =>1.9 uses 'rel', django <1.9 uses 'related'
+        # "rel" for FK and M2M relations and "related" for O2O Relations
         related = getattr(attr, "rel", None) or getattr(attr, "related", None)
         if isinstance(related, models.ManyToOneRel):
             yield (name, related)

--- a/graphene_django/utils/utils.py
+++ b/graphene_django/utils/utils.py
@@ -18,7 +18,8 @@ def get_reverse_fields(model, local_field_names):
         if name in local_field_names:
             continue
 
-        related = getattr(attr, "rel", None)
+        # Django =>1.9 uses 'rel', django <1.9 uses 'related'
+        related = getattr(attr, "rel", None) or getattr(attr, "related", None)
         if isinstance(related, models.ManyToOneRel):
             yield (name, related)
         elif isinstance(related, models.ManyToManyRel) and not related.symmetrical:


### PR DESCRIPTION
This PR fixes: #662 

I tested manually like this:
```python
def get_reverse_fields(model, local_field_names):
    for name, attr in model.__dict__.items():
        # Don't duplicate any local fields
        if name in local_field_names:
            continue
        r = getattr(attr, "rel", None)
        r2 = getattr(attr, "related", None)

        if r is not None or r2 is not None:
            print(r, r2)

        related = getattr(attr, "rel", None)
        if isinstance(related, models.ManyToOneRel):
            yield (name, related)
        elif isinstance(related, models.ManyToManyRel) and not related.symmetrical:
            yield (name, related)
```

And the result (on runserver output): 
```bash
<ManyToOneRel: event.companion> None
None <OneToOneRel: event.invitation>
```

Which means O2O relation is still using "related"