### PR TITLE
Enum conversion fixes

### DIFF
--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -1,6 +1,6 @@
 from .types import DjangoObjectType
 from .fields import DjangoConnectionField
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 __all__ = ["__version__", "DjangoObjectType", "DjangoConnectionField"]

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -28,10 +28,18 @@ from .utils import import_single_dispatch
 singledispatch = import_single_dispatch()
 
 
+def _is_dunder(name):
+    """Returns True if a __dunder__ name, False otherwise."""
+    return (len(name) > 4 and
+            name[:2] == name[-2:] == '__' and
+            name[2:3] != '_' and
+            name[-3:-2] != '_')
+
+
 def convert_choice_name(name):
     name = force_text(name).encode('utf8').decode('ascii', 'ignore')
     name = to_const(name)
-    if name.startswith('_'):
+    if _is_dunder(name):
         name = "A%s" % name
     try:
         assert_valid_name(name)

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -31,6 +31,8 @@ singledispatch = import_single_dispatch()
 def convert_choice_name(name):
     name = force_text(name).encode('utf8').decode('ascii', 'ignore')
     name = to_const(name)
+    if name.startswith('_'):
+        name = "A%s" % name
     try:
         assert_valid_name(name)
     except AssertionError:

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -30,22 +30,26 @@ singledispatch = import_single_dispatch()
 
 def _is_dunder(name):
     """Returns True if a __dunder__ name, False otherwise."""
-    return (len(name) > 4 and
-            name[:2] == name[-2:] == '__' and
-            name[2:3] != '_' and
-            name[-3:-2] != '_')
+    return (
+        len(name) > 4
+        and name[:2] == name[-2:] == "__"
+        and name[2:3] != "_"
+        and name[-3:-2] != "_"
+    )
 
 
 def _is_sunder(name):
     """Returns True if a _sunder_ name, False otherwise."""
-    return (len(name) > 2 and
-            name[0] == name[-1] == '_' and
-            name[1:2] != '_' and
-            name[-2:-1] != '_')
+    return (
+        len(name) > 2
+        and name[0] == name[-1] == "_"
+        and name[1:2] != "_"
+        and name[-2:-1] != "_"
+    )
 
 
 def convert_choice_name(name):
-    name = force_text(name).encode('utf8').decode('ascii', 'ignore')
+    name = force_text(name).encode("utf8").decode("ascii", "ignore")
     name = to_const(name)
     if _is_sunder(name) or _is_dunder(name):
         name = "A%s" % name

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -36,10 +36,18 @@ def _is_dunder(name):
             name[-3:-2] != '_')
 
 
+def _is_sunder(name):
+    """Returns True if a _sunder_ name, False otherwise."""
+    return (len(name) > 2 and
+            name[0] == name[-1] == '_' and
+            name[1:2] != '_' and
+            name[-2:-1] != '_')
+
+
 def convert_choice_name(name):
     name = force_text(name).encode('utf8').decode('ascii', 'ignore')
     name = to_const(name)
-    if _is_dunder(name):
+    if _is_sunder(name) or _is_dunder(name):
         name = "A%s" % name
     try:
         assert_valid_name(name)

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -29,7 +29,8 @@ singledispatch = import_single_dispatch()
 
 
 def convert_choice_name(name):
-    name = to_const(force_text(name))
+    name = force_text(name).encode('utf8').decode('ascii', 'ignore')
+    name = to_const(name)
     try:
         assert_valid_name(name)
     except AssertionError:

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 from django.db import models

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, "this"), (2, _("that")))
+CHOICES = ((1, "1: this"), (2, _("2: that")))
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, "1: this漢"), (2, _("2: that漢")))
+CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")))
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")), (3, "__amount__"))
+CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")), (u'_3漢', "__amount__"))
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")))
+CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")), (3, "__amount__"))
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -4,7 +4,13 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")), (u"_3漢", "__amount__"))
+CHOICES = (
+    (1, u"this"),
+    ("2", _(u"that")),
+    (u"_3漢", "nonascii"),
+    ("__dunder__", "dunder"),
+    ("_sunder_", "sunder"),
+)
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, "1: this"), (2, _("2: that")))
+CHOICES = ((1, "1: this漢"), (2, _("2: that漢")))
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")), (u'_3漢', "__amount__"))
+CHOICES = ((1, u"1: this漢"), (2, _(u"2: that漢")), (u"_3漢", "__amount__"))
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -199,7 +199,7 @@ def test_field_with_choices_collision():
 def test_field_with_choices_underscore():
     field = models.CharField(
         choices=(
-            ("__amount__", "Amount"),
+            ("_amount__", "Amount"),
             ("__percentage__", "Percentage"),
         ),
     )
@@ -212,8 +212,8 @@ def test_field_with_choices_underscore():
 
     graphene_type = convert_django_field_with_choices(field)
     assert len(graphene_type._meta.enum.__members__) == 2
-    assert graphene_type._meta.enum.__members__["A__AMOUNT__"].value == "__amount__"
-    assert graphene_type._meta.enum.__members__["A__AMOUNT__"].description == "Amount"
+    assert graphene_type._meta.enum.__members__["_AMOUNT__"].value == "_amount__"
+    assert graphene_type._meta.enum.__members__["_AMOUNT__"].description == "Amount"
     assert graphene_type._meta.enum.__members__["A__PERCENTAGE__"].value == "__percentage__"
     assert graphene_type._meta.enum.__members__["A__PERCENTAGE__"].description == "Percentage"
 

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -212,6 +212,10 @@ def test_field_with_choices_underscore():
 
     graphene_type = convert_django_field_with_choices(field)
     assert len(graphene_type._meta.enum.__members__) == 2
+    assert graphene_type._meta.enum.__members__["A__AMOUNT__"].value == "__amount__"
+    assert graphene_type._meta.enum.__members__["A__AMOUNT__"].description == "Amount"
+    assert graphene_type._meta.enum.__members__["A__PERCENTAGE__"].value == "__percentage__"
+    assert graphene_type._meta.enum.__members__["A__PERCENTAGE__"].description == "Percentage"
 
 
 def test_should_float_convert_float():

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -199,8 +199,10 @@ def test_field_with_choices_collision():
 def test_field_with_choices_underscore():
     field = models.CharField(
         choices=(
-            ("_amount__", "Amount"),
+            ("_amount_", "Amount"),
             ("__percentage__", "Percentage"),
+            ("_not_sunder__", "Not Single Underscore"),
+            ("__not_dunder", "Not Double Underscore"),
         ),
     )
 
@@ -211,12 +213,11 @@ def test_field_with_choices_underscore():
             app_label = "test"
 
     graphene_type = convert_django_field_with_choices(field)
-    assert len(graphene_type._meta.enum.__members__) == 2
-    assert graphene_type._meta.enum.__members__["_AMOUNT__"].value == "_amount__"
-    assert graphene_type._meta.enum.__members__["_AMOUNT__"].description == "Amount"
-    assert graphene_type._meta.enum.__members__["A__PERCENTAGE__"].value == "__percentage__"
-    assert graphene_type._meta.enum.__members__["A__PERCENTAGE__"].description == "Percentage"
-
+    assert len(graphene_type._meta.enum.__members__) == 4
+    assert "A_AMOUNT_" in graphene_type._meta.enum.__members__
+    assert "A__PERCENTAGE__" in graphene_type._meta.enum.__members__
+    assert "_NOT_SUNDER__" in graphene_type._meta.enum.__members__
+    assert "__NOT_DUNDER" in graphene_type._meta.enum.__members__
 
 def test_should_float_convert_float():
     assert_conversion(models.FloatField, graphene.Float)

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -196,6 +196,24 @@ def test_field_with_choices_collision():
     convert_django_field_with_choices(field)
 
 
+def test_field_with_choices_underscore():
+    field = models.CharField(
+        choices=(
+            ("__amount__", "Amount"),
+            ("__percentage__", "Percentage"),
+        ),
+    )
+
+    class UnderscoreChoicesModel(models.Model):
+        ourfield = field
+
+        class Meta:
+            app_label = "test"
+
+    graphene_type = convert_django_field_with_choices(field)
+    assert len(graphene_type._meta.enum.__members__) == 2
+
+
 def test_should_float_convert_float():
     assert_conversion(models.FloatField, graphene.Float)
 

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -172,8 +172,8 @@ type Reporter {
 }
 
 enum ReporterAChoice {
-  A_1
-  A_2
+  A_1_THIS
+  A_2_THAT
 }
 
 enum ReporterReporterType {

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -172,9 +172,9 @@ type Reporter {
 }
 
 enum ReporterAChoice {
-  A_1_THIS
-  A_2_THAT
-  A__AMOUNT__
+  A_1
+  A_2
+  A_3
 }
 
 enum ReporterReporterType {

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -174,7 +174,7 @@ type Reporter {
 enum ReporterAChoice {
   A_1
   A_2
-  A_3
+  _3
 }
 
 enum ReporterReporterType {

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -180,6 +180,8 @@ enum ReporterAChoice {
   A_1
   A_2
   _3
+  A__DUNDER__
+  A_SUNDER_
 }
 
 enum ReporterReporterType {

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -174,6 +174,7 @@ type Reporter {
 enum ReporterAChoice {
   A_1_THIS
   A_2_THAT
+  A__AMOUNT__
 }
 
 enum ReporterReporterType {


### PR DESCRIPTION
Collected backwards compatible fixes from #654 

Fixes #141 and allows using non-ascii characters as choice values.