### PR TITLE
resolve subtypes of postgres RangeField to new RangeType

### DIFF
--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -1,6 +1,6 @@
 from .types import DjangoObjectType
 from .fields import DjangoConnectionField
 
-__version__ = "2.3.0"
+__version__ = "2.3.2"
 
 __all__ = ["__version__", "DjangoObjectType", "DjangoConnectionField"]

--- a/graphene_django/compat.py
+++ b/graphene_django/compat.py
@@ -18,4 +18,6 @@ try:
         DecimalRangeField
     )
 except ImportError:
-    ArrayField, HStoreField, JSONField, RangeField = (MissingType,) * 4
+    ArrayField, HStoreField, JSONField, RangeField, \
+    DateTimeRangeField, DateRangeField, IntegerRangeField, \
+    BigIntegerRangeField, FloatRangeField, DecimalRangeField = (MissingType,) * 10

--- a/graphene_django/compat.py
+++ b/graphene_django/compat.py
@@ -10,6 +10,12 @@ try:
         HStoreField,
         JSONField,
         RangeField,
+        DateTimeRangeField,
+        DateRangeField,
+        IntegerRangeField,
+        BigIntegerRangeField,
+        FloatRangeField,
+        DecimalRangeField
     )
 except ImportError:
     ArrayField, HStoreField, JSONField, RangeField = (MissingType,) * 4

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -21,7 +21,26 @@ from graphene.types.json import JSONString
 from graphene.utils.str_converters import to_camel_case, to_const
 from graphql import assert_valid_name
 
-from .compat import ArrayField, HStoreField, JSONField, RangeField
+from .compat import (
+    ArrayField,
+    HStoreField,
+    JSONField,
+    RangeField,
+    DateTimeRangeField,
+    DateRangeField,
+    IntegerRangeField,
+    BigIntegerRangeField,
+    FloatRangeField,
+    DecimalRangeField
+)
+
+from .range_types import (
+    DateRangeType,
+    DateTimeRangeType,
+    IntRangeType,
+    FloatRangeType
+)
+
 from .fields import DjangoListField, DjangoConnectionField
 from .utils import import_single_dispatch
 
@@ -236,3 +255,21 @@ def convert_posgres_range_to_string(field, registry=None):
     if not isinstance(inner_type, (List, NonNull)):
         inner_type = type(inner_type)
     return List(inner_type, description=field.help_text, required=not field.null)
+
+@convert_django_field.register(DateTimeRangeField)
+def convert_posgres_datetime_range_to_datetime(field, registry=None):
+    return Field(DateTimeRangeType, description=field.help_text, required=not field.null)
+
+@convert_django_field.register(DateRangeField)
+def convert_posgres_date_range_to_date(field, registry=None):
+    return Field(DateRangeType, description=field.help_text, required=not field.null)
+
+@convert_django_field.register(IntegerRangeField)
+@convert_django_field.register(BigIntegerRangeField)
+def convert_posgres_int_range_to_int(field, registry=None):
+    return Field(IntRangeType, description=field.help_text, required=not field.null)
+
+@convert_django_field.register(FloatRangeField)
+@convert_django_field.register(DecimalRangeField)
+def convert_posgres_float_range_to_float(field, registry=None):
+    return Field(FloatRangeType, description=field.help_text, required=not field.null)

--- a/graphene_django/range_types.py
+++ b/graphene_django/range_types.py
@@ -1,0 +1,29 @@
+from graphene import ObjectType
+from graphene import (
+    Float,
+    Int,
+    DateTime,
+    Date
+)
+
+class RangeResolver:
+    def resolve_lower(parent, info):
+        return parent.lower
+    def resolve_upper(parent, info):
+        return parent.upper
+
+class DateTimeRangeType(RangeResolver, ObjectType):
+    lower = DateTime()
+    upper = DateTime()
+
+class DateRangeType(RangeResolver, ObjectType):
+    lower = Date()
+    upper = Date()
+
+class IntRangeType(RangeResolver, ObjectType):
+    lower = Int()
+    upper = Int()
+
+class FloatRangeType(RangeResolver, ObjectType):
+    lower = Float()
+    upper = Float()

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -165,3 +165,4 @@ class DjangoObjectType(ObjectType):
 class ErrorType(ObjectType):
     field = graphene.String(required=True)
     messages = graphene.List(graphene.NonNull(graphene.String), required=True)
+


### PR DESCRIPTION
Original implementation to resolve Django.contrib.postgres Range series fields to a List type,
which is not working for DateTimeTZRange ( at least for Django 2.2.x )

#675 

What I did is to resolve Range fields to specific RangeType with upper and lower fields inside it, like
```
my_range_filed {
upper
lower
}

I don't whether this is a good method, wish anyone can give me suggestion.
