### PR TITLE
Bugfix: Correct filter types for DjangoFilterConnectionFields

### DIFF
--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -183,7 +183,7 @@ def test_filter_shortcut_filterset_context():
     }
     """
     schema = Schema(query=Query)
-    result = schema.execute(query, context_value=context())
+    result = schema.execute(query, context=context())
     assert not result.errors
 
     assert len(result.data["contextArticles"]["edges"]) == 1
@@ -462,15 +462,15 @@ def test_filter_filterset_related_results_with_filter():
     class Query(ObjectType):
         all_reporters = DjangoFilterConnectionField(ReporterFilterNode)
 
-    r1 = Reporter.objects.create(
+    Reporter.objects.create(
         first_name="A test user", last_name="Last Name", email="test1@test.com"
     )
-    r2 = Reporter.objects.create(
+    Reporter.objects.create(
         first_name="Other test user",
         last_name="Other Last Name",
         email="test2@test.com",
     )
-    r3 = Reporter.objects.create(
+    Reporter.objects.create(
         first_name="Random", last_name="RandomLast", email="random@test.com"
     )
 
@@ -638,7 +638,7 @@ def test_should_query_filter_node_double_limit_raises():
     Reporter.objects.create(
         first_name="Bob", last_name="Doe", email="bobdoe@example.com", a_choice=2
     )
-    r = Reporter.objects.create(
+    Reporter.objects.create(
         first_name="John", last_name="Doe", email="johndoe@example.com", a_choice=1
     )
 
@@ -684,7 +684,7 @@ def test_order_by_is_perserved():
             return reporters
 
     Reporter.objects.create(first_name="b")
-    r = Reporter.objects.create(first_name="a")
+    Reporter.objects.create(first_name="a")
 
     schema = Schema(query=Query)
     query = """

--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -1,17 +1,16 @@
 from datetime import datetime
+from textwrap import dedent
 
 import pytest
+from django.db.models import TextField, Value
+from django.db.models.functions import Concat
 
-from graphene import Field, ObjectType, Schema, Argument, Float, Boolean, String
+from graphene import Argument, Boolean, Field, Float, ObjectType, Schema, String
 from graphene.relay import Node
 from graphene_django import DjangoObjectType
 from graphene_django.forms import GlobalIDFormField, GlobalIDMultipleChoiceField
 from graphene_django.tests.models import Article, Pet, Reporter
 from graphene_django.utils import DJANGO_FILTER_INSTALLED
-
-# for annotation test
-from django.db.models import TextField, Value
-from django.db.models.functions import Concat
 
 pytestmark = []
 

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -11,8 +11,25 @@ def get_filtering_args_from_filterset(filterset_class, type):
     from ..forms.converter import convert_form_field
 
     args = {}
+    model = filterset_class._meta.model
     for name, filter_field in six.iteritems(filterset_class.base_filters):
-        field_type = convert_form_field(filter_field.field).Argument()
+        if name in filterset_class.declared_filters:
+            form_field = filter_field.field
+        else:
+            field_name = name.split("__", 1)[0]
+            model_field = model._meta.get_field(field_name)
+
+            if hasattr(model_field, "formfield"):
+                form_field = model_field.formfield(
+                    required=filter_field.extra.get("required", False)
+                )
+
+            # Fallback to field defined on filter if we can't get it from the
+            # model field
+            if not form_field:
+                form_field = filter_field.field
+
+        field_type = convert_form_field(form_field).Argument()
         field_type.description = filter_field.label
         args[name] = field_type
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,8 @@ omit = */tests/*
 
 [isort]
 known_first_party=graphene,graphene_django
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88


### PR DESCRIPTION
Fixes #678 

For Django IntegerFields, Django-filter converts it to a [NumberFilter](https://django-filter.readthedocs.io/en/master/ref/filters.html#numberfilter) and NumberFilter defines it's Django form field as a [DecimalField](https://github.com/carltongibson/django-filter/blob/master/django_filters/filters.py#L361-L362). Graphene-Django then uses that form field to determine the GraphQL type to use for the filter, so in this case an IntegerField defined on the model gets converted into a Float argument when used as a filter.

This PR changes the logic so that (if it can) it uses the Django model field to determine the corresponding form field rather than Django-filter.

In this PR I've also cleaned up the `test_fields` file a bit and added a black compatible config for isort.