### PR TITLE
2.3.2 release

### DIFF
--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -1,6 +1,6 @@
 from .types import DjangoObjectType
 from .fields import DjangoConnectionField
 
-__version__ = "2.3.0"
+__version__ = "2.3.2"
 
 __all__ = ["__version__", "DjangoObjectType", "DjangoConnectionField"]


### PR DESCRIPTION
2.3.1 did not work, so we are releasing 2.3.2 to resolve this as we can't remove a version from pypi.

@mvanlonden @jkimbo - I am sure I have to do more than this to make it work?