### PR TITLE
Adds documentation to `CAMELCASE_ERRORS` setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -116,3 +116,27 @@ Default: ``False``
    GRAPHENE = {
       'CAMELCASE_ERRORS': False,
    }
+
+   # result = schema.execute(...)
+   print(result.errors)
+   # [
+   #     {
+   #         'field': 'test_field',
+   #         'messages': ['This field is required.'],
+   #     }
+   # ]
+
+.. code:: python
+
+   GRAPHENE = {
+      'CAMELCASE_ERRORS': True,
+   }
+
+   # result = schema.execute(...)
+   print(result.errors)
+   # [
+   #     {
+   #         'field': 'testField',
+   #         'messages': ['This field is required.'],
+   #     }
+   # ]

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -101,3 +101,18 @@ Default: ``100``
     GRAPHENE = {
         'RELAY_CONNECTION_MAX_LIMIT': 100,
     }
+
+
+``CAMELCASE_ERRORS``
+------------------------------------
+
+When set to ``True`` field names in the ``errors`` object will be camel case.
+By default they will be snake case.
+
+Default: ``False``
+
+.. code:: python
+
+   GRAPHENE = {
+      'CAMELCASE_ERRORS': False,
+   }

--- a/graphene_django/forms/tests/test_mutation.py
+++ b/graphene_django/forms/tests/test_mutation.py
@@ -53,10 +53,10 @@ def test_mutation_error_camelcased():
 
     result = PetMutation.mutate_and_get_payload(None, None)
     assert {f.field for f in result.errors} == {"name", "age", "test_field"}
-    graphene_settings.DJANGO_GRAPHENE_CAMELCASE_ERRORS = True
+    graphene_settings.CAMELCASE_ERRORS = True
     result = PetMutation.mutate_and_get_payload(None, None)
     assert {f.field for f in result.errors} == {"name", "age", "testField"}
-    graphene_settings.DJANGO_GRAPHENE_CAMELCASE_ERRORS = False
+    graphene_settings.CAMELCASE_ERRORS = False
 
 
 class ModelFormMutationTests(TestCase):

--- a/graphene_django/rest_framework/tests/test_mutation.py
+++ b/graphene_django/rest_framework/tests/test_mutation.py
@@ -215,10 +215,10 @@ def test_model_mutate_and_get_payload_error():
 
 
 def test_mutation_error_camelcased():
-    graphene_settings.DJANGO_GRAPHENE_CAMELCASE_ERRORS = True
+    graphene_settings.CAMELCASE_ERRORS = True
     result = MyModelMutation.mutate_and_get_payload(None, mock_info(), **{})
     assert result.errors[0].field == "coolName"
-    graphene_settings.DJANGO_GRAPHENE_CAMELCASE_ERRORS = False
+    graphene_settings.CAMELCASE_ERRORS = False
 
 
 def test_invalid_serializer_operations():

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -35,7 +35,7 @@ DEFAULTS = {
     "RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST": False,
     # Max items returned in ConnectionFields / FilterConnectionFields
     "RELAY_CONNECTION_MAX_LIMIT": 100,
-    "DJANGO_GRAPHENE_CAMELCASE_ERRORS": False,
+    "CAMELCASE_ERRORS": False,
 }
 
 if settings.DEBUG:

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -192,4 +192,4 @@ class ErrorType(ObjectType):
     @classmethod
     def from_errors(cls, errors):
         data = camelize(errors) if graphene_settings.CAMELCASE_ERRORS else errors
-        return [ErrorType(field=key, messages=value) for key, value in data.items()]
+        return [cls(field=key, messages=value) for key, value in data.items()]

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -191,9 +191,5 @@ class ErrorType(ObjectType):
 
     @classmethod
     def from_errors(cls, errors):
-        data = (
-            camelize(errors)
-            if graphene_settings.DJANGO_GRAPHENE_CAMELCASE_ERRORS
-            else errors
-        )
+        data = camelize(errors) if graphene_settings.CAMELCASE_ERRORS else errors
         return [ErrorType(field=key, messages=value) for key, value in data.items()]


### PR DESCRIPTION
Following on from https://github.com/graphql-python/graphene-django/pull/514 this PR renames the setting to `CAMELCASE_ERRORS` (the `DJANGO_GRAPHENE` part was unnecessary since it's in the `GRAPHENE` setting already) and adds documentation for the setting.

FYI @kalekseev 