### PR TITLE
Enforce NonNull for returned related Sets and their content

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -198,7 +198,9 @@ def convert_field_to_list_or_connection(field, registry=None):
 
             return DjangoConnectionField(_type, description=description)
 
-        return DjangoListField(_type, description=description)
+        return DjangoListField(_type,
+                               required=True,  # A Set is always returned, never None.
+                               description=description)
 
     return Dynamic(dynamic_type)
 

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -198,9 +198,11 @@ def convert_field_to_list_or_connection(field, registry=None):
 
             return DjangoConnectionField(_type, description=description)
 
-        return DjangoListField(_type,
-                               required=True,  # A Set is always returned, never None.
-                               description=description)
+        return DjangoListField(
+            _type,
+            required=True,  # A Set is always returned, never None.
+            description=description,
+        )
 
     return Dynamic(dynamic_type)
 

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -15,7 +15,8 @@ from .utils import maybe_queryset
 
 class DjangoListField(Field):
     def __init__(self, _type, *args, **kwargs):
-        super(DjangoListField, self).__init__(List(_type), *args, **kwargs)
+        # Django would never return a Set of None  vvvvvvv
+        super(DjangoListField, self).__init__(List(NonNull(_type)), *args, **kwargs)
 
     @property
     def model(self):

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -1,6 +1,7 @@
 import pytest
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from graphene import NonNull
 from py.test import raises
 
 import graphene
@@ -234,8 +235,12 @@ def test_should_manytomany_convert_connectionorlist_list():
     assert isinstance(graphene_field, graphene.Dynamic)
     dynamic_field = graphene_field.get_type()
     assert isinstance(dynamic_field, graphene.Field)
-    assert isinstance(dynamic_field.type, graphene.List)
-    assert dynamic_field.type.of_type == A
+    # A NonNull List of NonNull A ([A!]!)
+    # https://github.com/graphql-python/graphene-django/issues/448
+    assert isinstance(dynamic_field.type, NonNull)
+    assert isinstance(dynamic_field.type.of_type, graphene.List)
+    assert isinstance(dynamic_field.type.of_type.of_type, NonNull)
+    assert dynamic_field.type.of_type.of_type.of_type == A
 
 
 def test_should_manytomany_convert_connectionorlist_connection():
@@ -262,8 +267,12 @@ def test_should_manytoone_convert_connectionorlist():
     assert isinstance(graphene_field, graphene.Dynamic)
     dynamic_field = graphene_field.get_type()
     assert isinstance(dynamic_field, graphene.Field)
-    assert isinstance(dynamic_field.type, graphene.List)
-    assert dynamic_field.type.of_type == A
+    # a NonNull List of NonNull A ([A!]!)
+    assert isinstance(dynamic_field.type, NonNull)
+    assert isinstance(dynamic_field.type.of_type, graphene.List)
+    assert isinstance(dynamic_field.type.of_type.of_type, NonNull)
+    assert isinstance(dynamic_field.type.of_type.of_type, NonNull)
+    assert dynamic_field.type.of_type.of_type.of_type == A
 
 
 def test_should_onetoone_reverse_convert_model():

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -271,7 +271,6 @@ def test_should_manytoone_convert_connectionorlist():
     assert isinstance(dynamic_field.type, NonNull)
     assert isinstance(dynamic_field.type.of_type, graphene.List)
     assert isinstance(dynamic_field.type.of_type.of_type, NonNull)
-    assert isinstance(dynamic_field.type.of_type.of_type, NonNull)
     assert dynamic_field.type.of_type.of_type.of_type == A
 
 

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -170,7 +170,7 @@ type Reporter {
   firstName: String!
   lastName: String!
   email: String!
-  pets: [Reporter]
+  pets: [Reporter!]!
   aChoice: ReporterAChoice!
   reporterType: ReporterReporterType
   articles(before: String, after: String, first: Int, last: Int): ArticleConnection


### PR DESCRIPTION
As discussed in https://github.com/graphql-python/graphene-django/issues/44 : when you retrieve the related Set of an object, 
1. You never get None : when no related items are returned, you get an empty Set.
2. You never, ever get a Set of None.
This PR enforces the fact that the Set is NonNull, and so is each object in the Set.

(PR recreated from https://github.com/graphql-python/graphene-django/pull/681 by @dperetti)