### PR TITLE
Fix manager check in DjangoConnectionField

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -101,7 +101,7 @@ class DjangoConnectionField(ConnectionField):
             iterable = default_manager
         iterable = maybe_queryset(iterable)
         if isinstance(iterable, QuerySet):
-            if iterable is not default_manager:
+            if iterable.model.objects is not default_manager:
                 default_queryset = maybe_queryset(default_manager)
                 iterable = cls.merge_querysets(default_queryset, iterable)
             _len = iterable.count()


### PR DESCRIPTION
Fixes #327

This fix means that querysets only get merged with the default queryset if they are different rather than all the time (which is currently the case). As a result things like `prefetch_related` calls are preserved which should improve performance significantly.