### PR TITLE
Adds variables arg to GraphQLTestCase.query

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -37,6 +37,28 @@ Usage:
             # Add some more asserts if you like
             ...
 
+        def test_query_with_variables(self):
+            response = self.query(
+                '''
+                query myModel($id: Int!){
+                    myModel(id: $id) {
+                        id
+                        name
+                    }
+                }
+                ''',
+                op_name='myModel',
+                variables={'id': 1}
+            )
+
+            content = json.loads(response.content)
+
+            # This validates the status code and if you get errors
+            self.assertResponseNoErrors(response)
+
+            # Add some more asserts if you like
+            ...
+
         def test_some_mutation(self):
             response = self.query(
                 '''

--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -24,7 +24,7 @@ class GraphQLTestCase(TestCase):
 
         cls._client = Client()
 
-    def query(self, query, op_name=None, input_data=None):
+    def query(self, query, op_name=None, input_data=None, variables=None):
         """
         Args:
             query (string)    - GraphQL query to run
@@ -40,8 +40,13 @@ class GraphQLTestCase(TestCase):
         body = {"query": query}
         if op_name:
             body["operation_name"] = op_name
+        if variables:
+            body["variables"] = variables
         if input_data:
-            body["variables"] = {"input": input_data}
+            if variables in body and isinstance(body, dict):
+                body["variables"]["input"] = input_data
+            else:
+                body["variables"] = {"input": input_data}
 
         resp = self._client.post(
             self.GRAPHQL_URL, json.dumps(body), content_type="application/json"

--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -32,7 +32,11 @@ class GraphQLTestCase(TestCase):
                                 supply the op_name.  For annon queries ("{ ... }"),
                                 should be None (default).
             input_data (dict) - If provided, the $input variable in GraphQL will be set
-                                to this value
+                                to this value. If both ``input_data`` and ``variables``, 
+                                are provided, the ``input`` field in the ``variables``
+                                dict will be overwritten with this value.
+            variables (dict)  - If provided, the "variables" field in GraphQL will be
+                                set to this value. 
 
         Returns:
             Response object from client
@@ -43,7 +47,7 @@ class GraphQLTestCase(TestCase):
         if variables:
             body["variables"] = variables
         if input_data:
-            if variables in body and isinstance(body, dict):
+            if variables in body:
                 body["variables"]["input"] = input_data
             else:
                 body["variables"] = {"input": input_data}


### PR DESCRIPTION
I was looking for a way to test queries with variables, and formatting the query string directly was a little messy, and I didn't need anything as complex as a custom `input_type`.  If you would prefer I accomplish this by subclassing `GraphQLTestCase`, I understand... but here's a PR just in case you find it useful.  Also added an example to the docs.