### PR TITLE
v2.4.0

### DIFF
--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -1,6 +1,6 @@
 from .types import DjangoObjectType
 from .fields import DjangoConnectionField
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 __all__ = ["__version__", "DjangoObjectType", "DjangoConnectionField"]


### PR DESCRIPTION
Release notes:

---

# Changelog

Some great new features and lots of bugfixes in this release. A massive thanks to all the contributors that helped out! This release will probably be the last one before v3 (see https://github.com/graphql-python/graphene-django/issues/705)

## New features

* Add support for write_only fields in SerializerMutation (#555)
* Enhanced support for proxy models (#603)
* Add support for filterset_class meta parameter (#600)
* Add watch option to graphql_schema management command (#656)
* Add `convert_choices_to_enum` option on DjangoObjectType Meta class (#674)
* Add option `CAMELCASE_ERRORS` to camel case field names in DRF errors (#514 and #689)
* Mark content of ManyTo* relationships as NonNull (#690)
* Alias `only_fields` as `fields` and `exclude_fields` as `exclude` (#691)

## Bugfixes

* Stop enforcing csrf checks in GraphQLTestCase (#658)
* Correctly propagate help_text as description for many-to-* relations (#579)
* Fix Django manager check in DjangoConnectionField (which was preventing `prefetch_related` optimisations from working) (#693)
* Remove duplicate ErrorType (#701)
* Ensure correct filter types for DjangoFilterConnectionFields (#682)
* Fix error of multiple inputs with the same type. When using same serializer. (#530)

Full changelog: https://github.com/graphql-python/graphene-django/compare/v2.3.1...v2.4.0