### PR TITLE
fix choices enum: if field can be blank then it isn't required

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -73,7 +73,8 @@ def convert_django_field_with_choices(
                 return named_choices_descriptions[self.name]
 
         enum = Enum(name, list(named_choices), type=EnumWithDescriptionsType)
-        converted = enum(description=field.help_text, required=not field.null)
+        required = not (field.blank or field.null)
+        converted = enum(description=field.help_text, required=required)
     else:
         converted = convert_django_field(field, registry)
     if registry is not None:

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -38,7 +38,7 @@ class Reporter(models.Model):
     last_name = models.CharField(max_length=30)
     email = models.EmailField()
     pets = models.ManyToManyField("self")
-    a_choice = models.CharField(max_length=30, choices=CHOICES)
+    a_choice = models.CharField(max_length=30, choices=CHOICES, blank=True)
     objects = models.Manager()
     doe_objects = DoeReporterManager()
 

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -171,7 +171,7 @@ type Reporter {
   lastName: String!
   email: String!
   pets: [Reporter!]!
-  aChoice: ReporterAChoice!
+  aChoice: ReporterAChoice
   reporterType: ReporterReporterType
   articles(before: String, after: String, first: Int, last: Int): ArticleConnection
 }


### PR DESCRIPTION
This is to fix #503 ; When a user defines `CharField` with `blank=True` and `choices` then it should not be marked as required.

One deviation from the proposed solution from the issue is the checking of whether the field as a default value. I am not sure if that is appropriate.