### PR TITLE
Check for filters defined on base filterset classes

### DIFF
--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -892,6 +892,7 @@ def test_filter_filterset_based_on_mixin():
             allArticles(viewer_Email_In: "%s") {
                 edges {
                     node {
+                        headline
                         viewer {
                             email
                         }
@@ -904,7 +905,16 @@ def test_filter_filterset_based_on_mixin():
     )
 
     expected = {
-        "allArticles": {"edges": [{"node": {"viewer": {"email": reporter_1.email}}}]}
+        "allArticles": {
+            "edges": [
+                {
+                    "node": {
+                        "headline": article_1.headline,
+                        "viewer": {"email": reporter_1.email},
+                    }
+                }
+            ]
+        }
     }
 
     result = schema.execute(query)

--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -821,17 +821,17 @@ def test_integer_field_filter_type():
 
 
 def test_filter_filterset_based_on_mixin():
-    class ArticleFilterMixin:
-
+    class ArticleFilterMixin(FilterSet):
         @classmethod
         def get_filters(cls):
-            filters = super().get_filters()
-            filters.update({
-                'viewer__email__in': django_filters.CharFilter(
-                    method='filter_email_in',
-                    field_name='reporter__email__in',
-                ),
-            })
+            filters = super(FilterSet, cls).get_filters()
+            filters.update(
+                {
+                    "viewer__email__in": django_filters.CharFilter(
+                        method="filter_email_in", field_name="reporter__email__in"
+                    )
+                }
+            )
 
             return filters
 
@@ -858,14 +858,16 @@ def test_filter_filterset_based_on_mixin():
         all_articles = DjangoFilterConnectionField(NewArticleFilterNode)
 
     reporter = Reporter.objects.create(
-        first_name="John", last_name="Doe", email="john@doe.com")
+        first_name="John", last_name="Doe", email="john@doe.com"
+    )
 
     article = Article.objects.create(
         headline="Hello",
         reporter=reporter,
         editor=reporter,
         pub_date=datetime.now(),
-        pub_date_time=datetime.now())
+        pub_date_time=datetime.now(),
+    )
 
     schema = Schema(query=Query)
 
@@ -884,17 +886,7 @@ def test_filter_filterset_based_on_mixin():
     """
 
     expected = {
-        "allArticles": {
-            "edges": [
-                {
-                    "node": {
-                        "viewer": {
-                            "email": reporter.email,
-                        }
-                    }
-                }
-            ]
-        }
+        "allArticles": {"edges": [{"node": {"viewer": {"email": reporter.email}}}]}
     }
 
     result = schema.execute(query)

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -13,21 +13,25 @@ def get_filtering_args_from_filterset(filterset_class, type):
     args = {}
     model = filterset_class._meta.model
     for name, filter_field in six.iteritems(filterset_class.base_filters):
+        form_field = None
+
         if name in filterset_class.declared_filters:
             form_field = filter_field.field
         else:
             field_name = name.split("__", 1)[0]
-            model_field = model._meta.get_field(field_name)
 
-            if hasattr(model_field, "formfield"):
-                form_field = model_field.formfield(
-                    required=filter_field.extra.get("required", False)
-                )
+            if hasattr(model, field_name):
+                model_field = model._meta.get_field(field_name)
 
-            # Fallback to field defined on filter if we can't get it from the
-            # model field
-            if not form_field:
-                form_field = filter_field.field
+                if hasattr(model_field, "formfield"):
+                    form_field = model_field.formfield(
+                        required=filter_field.extra.get("required", False)
+                    )
+
+        # Fallback to field defined on filter if we can't get it from the
+        # model field
+        if not form_field:
+            form_field = filter_field.field
 
         field_type = convert_form_field(form_field).Argument()
         field_type.description = filter_field.label


### PR DESCRIPTION
Fixes #729, an issue with getting filter args from filtersets that have a base class with common filters, which was crashing.