### PR TITLE
v2.5.0

### DIFF
--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -1,6 +1,6 @@
 from .types import DjangoObjectType
 from .fields import DjangoConnectionField
 
-__version__ = "2.4.0"
+__version__ = "2.5.0"
 
 __all__ = ["__version__", "DjangoObjectType", "DjangoConnectionField"]


### PR DESCRIPTION
Release notes:

---

# Changelog

Squeezing in another release before v3. Mostly bug fixes but also a change to the parts that are required in DjangoConnectionField and DjangoFilterConnectionField which might require a schema update.

## New features

* Set converted Django connections to required (#610)

## Bugfixes

* Fix choices enum: if field can be blank then it isn't required (#714)
* Check for filters defined on base filterset classes (#730)
* Make DjangoDebugContext wait for nested fields (#591)

Full changelog: https://github.com/graphql-python/graphene-django/compare/v2.4.0...v2.5.0