### PR TITLE
Raise exception for internal server error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,8 @@ serve the queries.
         url(r'^graphql$', GraphQLView.as_view(graphiql=True)),
     ]
 
+    handler500 = 'graphene_django.views.server_error'
+
 Examples
 --------
 

--- a/graphene_django/tests/test_views.py
+++ b/graphene_django/tests/test_views.py
@@ -1,6 +1,8 @@
 import json
 
 import pytest
+from mock import patch
+import django.http
 
 try:
     from urllib import urlencode
@@ -558,3 +560,15 @@ def test_passes_request_into_context_request(client):
 
     assert response.status_code == 200
     assert response_json(response) == {"data": {"request": "testing"}}
+
+
+def test_response_500(client):
+    with pytest.raises(RuntimeError), patch('graphql.backend.core.execute_and_validate', side_effect=RuntimeError):
+        response = client.get(url_string(query="{request}", q="testing"))
+
+
+def test_response_500_handler(client):
+    import graphene_django.views
+    response = graphene_django.views.server_error(django.http.HttpRequest())
+    assert response.status_code == 500
+    assert response_json(response) == {"errors": ["server error"]}

--- a/graphene_django/tests/urls.py
+++ b/graphene_django/tests/urls.py
@@ -6,3 +6,5 @@ urlpatterns = [
     url(r"^graphql/batch", GraphQLView.as_view(batch=True)),
     url(r"^graphql", GraphQLView.as_view(graphiql=True)),
 ]
+
+handler500 = 'graphene_django.views.server_error'

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -4,11 +4,11 @@ import re
 
 import six
 from django.http import HttpResponse, HttpResponseNotAllowed
-from django.http.response import HttpResponseBadRequest
+from django.http.response import HttpResponseBadRequest, HttpResponseServerError
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.generic import View
-from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.csrf import ensure_csrf_cookie, requires_csrf_token
 
 from graphql import get_default_backend
 from graphql.error import format_error as format_graphql_error
@@ -338,3 +338,8 @@ class GraphQLView(View):
         meta = request.META
         content_type = meta.get("CONTENT_TYPE", meta.get("HTTP_CONTENT_TYPE", ""))
         return content_type.split(";", 1)[0].lower()
+
+
+@requires_csrf_token
+def server_error(request, template_name=None):
+    return HttpResponseServerError('{"errors":["server error"]}', content_type='application/json')


### PR DESCRIPTION
During a heavy load of requests executor could crash (internal server error) but response status code remains `400` with error message `{'errors': [{'message': 'pop from an empty deque'}]}`, however expected behaviour is raising an exception and return response with status code `500` to the client.