### PR TITLE
converter.py: Fix typo posgres->postgres

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -235,12 +235,12 @@ def convert_postgres_array_to_list(field, registry=None):
 
 @convert_django_field.register(HStoreField)
 @convert_django_field.register(JSONField)
-def convert_posgres_field_to_string(field, registry=None):
+def convert_postgres_field_to_string(field, registry=None):
     return JSONString(description=field.help_text, required=not field.null)
 
 
 @convert_django_field.register(RangeField)
-def convert_posgres_range_to_string(field, registry=None):
+def convert_postgres_range_to_string(field, registry=None):
     inner_type = convert_django_field(field.base_field)
     if not isinstance(inner_type, (List, NonNull)):
         inner_type = type(inner_type)


### PR DESCRIPTION
Fixes typo for HStoreField and RangeField converters.