### PR TITLE
Pin higher version of graphene for proper graphql-core version resolution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     install_requires=[
         "six>=1.10.0",
-        "graphene>=2.1.3,<3",
+        "graphene>=2.1.7,<3",
         "graphql-core>=2.1.0,<3",
         "Django>=1.11",
         "singledispatch>=3.4.0.3",


### PR DESCRIPTION
```
$ pip-compile --generate-hashes requirements.in --output-file requirements.txt
Could not find a version that matches graphql-core<2,<3,>=0.5.0,>=2.1,>=2.1.0 (from graphene-django==2.5.0->-r requirements.in (line 43))
Tried: 0.4.9, 0.4.11, 0.4.12, 0.4.12.1, 0.4.13, 0.4.14, 0.4.15, 0.4.16, 0.4.17, 0.4.18, 0.5, 0.5.1, 0.5.2, 0.5.3, 1.0, 1.0.1, 1.1, 2.0, 2.0, 2.1, 2.1, 2.2, 2.2, 2.2.1, 2.2.1
Skipped pre-versions: 0.1a0, 0.1a1, 0.1a2, 0.1a3, 0.1a4, 0.4.7b0, 0.4.7b1, 0.4.7b2, 0.5b1, 0.5b2, 0.5b3, 1.0.dev20160814231515, 1.0.dev20160822075425, 1.0.dev20160823054952, 1.0.dev20160909030348, 1.0.dev20160909040033, 1.0.dev20160920065
529, 1.2.dev20170724044604, 2.0.dev20170801041408, 2.0.dev20170801041408, 2.0.dev20170801051721, 2.0.dev20170801051721, 2.0.dev20171009101843, 2.0.dev20171009101843, 2.1rc0, 2.1rc0, 2.1rc1, 2.1rc1, 2.1rc2, 2.1rc2, 2.1rc3, 2.1rc3, 3.0.0a0,
 3.0.0a0, 3.0.0a1, 3.0.0a1, 3.0.0a2, 3.0.0a2
There are incompatible versions in the resolved dependencies:
  graphql-core<2,>=0.5.0 (from graphql-relay==0.4.5->graphene==2.1.3->graphene-django==2.5.0->-r requirements.in (line 43))
  graphql-core<3,>=2.1 (from graphene==2.1.3->graphene-django==2.5.0->-r requirements.in (line 43))
  graphql-core<3,>=2.1.0 (from graphene-django==2.5.0->-r requirements.in (line 43))
```

Graphene 2.1.7 has the correct version of graphql-relay pinned