### PR TITLE
Upgrade graphiql version to fix history tool

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -51,7 +51,7 @@ def instantiate_middleware(middlewares):
 
 
 class GraphQLView(View):
-    graphiql_version = "0.13.0"
+    graphiql_version = "0.14.0"
     graphiql_template = "graphene/graphiql.html"
     react_version = "16.8.6"
 


### PR DESCRIPTION
Graphiql has a history tool that allows you to save and label favourites, but this version has a bug (fixed https://github.com/graphql/graphiql/issues/750). This change upgrades to the latest version.