### PR TITLE
Convert nullable BooleanField to nullable Boolean.

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -127,13 +127,9 @@ def convert_field_to_int(field, registry=None):
     return Int(description=field.help_text, required=not field.null)
 
 
+@convert_django_field.register(models.NullBooleanField)
 @convert_django_field.register(models.BooleanField)
 def convert_field_to_boolean(field, registry=None):
-    return NonNull(Boolean, description=field.help_text)
-
-
-@convert_django_field.register(models.NullBooleanField)
-def convert_field_to_nullboolean(field, registry=None):
     return Boolean(description=field.help_text, required=not field.null)
 
 

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -132,7 +132,8 @@ def test_should_boolean_convert_boolean():
 
 
 def test_should_boolean_convert_non_null_boolean():
-    field = assert_conversion(models.BooleanField, graphene.NonNull, null=False)
+    field = assert_conversion(models.BooleanField, graphene.Boolean, null=False)
+    assert isinstance(field.type, graphene.NonNull)
     assert field.type.of_type == graphene.Boolean
 
 

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -20,12 +20,19 @@ from .models import Article, Film, FilmDetails, Reporter
 
 
 def assert_conversion(django_field, graphene_field, *args, **kwargs):
-    field = django_field(help_text="Custom Help Text", null=True, *args, **kwargs)
+    _kwargs = kwargs.copy()
+    if "null" not in kwargs:
+        _kwargs["null"] = True
+    field = django_field(help_text="Custom Help Text", *args, **_kwargs)
     graphene_type = convert_django_field(field)
     assert isinstance(graphene_type, graphene_field)
     field = graphene_type.Field()
     assert field.description == "Custom Help Text"
-    nonnull_field = django_field(null=False, *args, **kwargs)
+
+    _kwargs = kwargs.copy()
+    if "null" not in kwargs:
+        _kwargs["null"] = False
+    nonnull_field = django_field(*args, **_kwargs)
     if not nonnull_field.null:
         nonnull_graphene_type = convert_django_field(nonnull_field)
         nonnull_field = nonnull_graphene_type.Field()
@@ -121,7 +128,11 @@ def test_should_integer_convert_int():
 
 
 def test_should_boolean_convert_boolean():
-    field = assert_conversion(models.BooleanField, graphene.NonNull)
+    assert_conversion(models.BooleanField, graphene.Boolean, null=True)
+
+
+def test_should_boolean_convert_non_null_boolean():
+    field = assert_conversion(models.BooleanField, graphene.NonNull, null=False)
     assert field.type.of_type == graphene.Boolean
 
 


### PR DESCRIPTION
BooleanFields can now be made nullable using `null=True` in Django. Graphene used to convert all BooleanFields to a NonNull type; this commit fixes converting nullable BooleanFields.

Fixes #486.