### PR TITLE
Add raise exception on serializer validation

### DIFF
--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -124,7 +124,7 @@ class SerializerMutation(ClientIDMutation):
         kwargs = cls.get_serializer_kwargs(root, info, **input)
         serializer = cls._meta.serializer_class(**kwargs)
 
-        if serializer.is_valid():
+        if serializer.is_valid(raise_exception=True):
             return cls.perform_mutate(serializer, info)
         else:
             errors = ErrorType.from_errors(serializer.errors)

--- a/graphene_django/rest_framework/tests/test_mutation.py
+++ b/graphene_django/rest_framework/tests/test_mutation.py
@@ -1,6 +1,8 @@
 import datetime
 
 from py.test import mark, raises
+from rest_framework.exceptions import ValidationError
+
 from rest_framework import serializers
 
 from graphene import Field, ResolveInfo
@@ -204,20 +206,23 @@ def test_mutate_and_get_payload_error():
             serializer_class = MySerializer
 
     # missing required fields
-    result = MyMutation.mutate_and_get_payload(None, mock_info(), **{})
-    assert len(result.errors) > 0
+    with raises(ValidationError):
+        result = MyMutation.mutate_and_get_payload(None, mock_info(), **{})
+        assert len(result.errors) > 0
 
 
 def test_model_mutate_and_get_payload_error():
     # missing required fields
-    result = MyModelMutation.mutate_and_get_payload(None, mock_info(), **{})
-    assert len(result.errors) > 0
+    with raises(ValidationError):
+        result = MyModelMutation.mutate_and_get_payload(None, mock_info(), **{})
+        assert len(result.errors) > 0
 
 
 def test_mutation_error_camelcased():
     graphene_settings.CAMELCASE_ERRORS = True
-    result = MyModelMutation.mutate_and_get_payload(None, mock_info(), **{})
-    assert result.errors[0].field == "coolName"
+    with raises(ValidationError):
+        result = MyModelMutation.mutate_and_get_payload(None, mock_info(), **{})
+        assert result.errors[0].field == "coolName"
     graphene_settings.CAMELCASE_ERRORS = False
 
 

--- a/graphene_django/tests/test_views.py
+++ b/graphene_django/tests/test_views.py
@@ -446,7 +446,6 @@ def test_handles_field_errors_caught_by_graphql(client):
     response = client.get(url_string(query="{thrower}"))
     assert response.status_code == 400
     assert response_json(response) == {
-        "data": None,
         "errors": [
             {
                 "locations": [{"column": 2, "line": 1}],

--- a/graphene_django/tests/test_views.py
+++ b/graphene_django/tests/test_views.py
@@ -444,7 +444,7 @@ def test_supports_pretty_printing_by_request(client):
 
 def test_handles_field_errors_caught_by_graphql(client):
     response = client.get(url_string(query="{thrower}"))
-    assert response.status_code == 200
+    assert response.status_code == 400
     assert response_json(response) == {
         "data": None,
         "errors": [

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -273,7 +273,7 @@ class GraphQLView(View):
                 # executor is not a valid argument in all backends
                 extra_options["executor"] = self.executor
 
-            return document.execute(
+            execution_result = document.execute(
                 root=self.get_root_value(request),
                 variables=variables,
                 operation_name=operation_name,
@@ -281,6 +281,9 @@ class GraphQLView(View):
                 middleware=self.get_middleware(request),
                 **extra_options
             )
+            if execution_result.errors:
+                return ExecutionResult(errors=execution_result.errors, invalid=True)
+            return execution_result
         except Exception as e:
             return ExecutionResult(errors=[e], invalid=True)
 


### PR DESCRIPTION
SerializerMutation with invalid input doesn't return any validation errors.  
- on graphql browser
<img width="1330" alt="Screen Shot 2019-10-13 at 7 09 41 AM" src="https://user-images.githubusercontent.com/26595506/66708290-20511d00-ed89-11e9-9031-822f36de53eb.png">  
- on ajax request  
<img width="815" alt="Screen Shot 2019-10-13 at 7 24 02 AM" src="https://user-images.githubusercontent.com/26595506/66708374-8b4f2380-ed8a-11e9-8e5d-2136efd622f8.png">

(In my case, content input shouldn't be blank.)
  
I think we need to add argument raise_exception=True on serializer.is_valid().
- on graphql browser  
<img width="1331" alt="Screen Shot 2019-10-13 at 7 10 10 AM" src="https://user-images.githubusercontent.com/26595506/66708329-cd2b9a00-ed89-11e9-8f0f-6fc706d5db4d.png">
- on ajax request  
<img width="814" alt="Screen Shot 2019-10-13 at 7 24 35 AM" src="https://user-images.githubusercontent.com/26595506/66708380-a4f06b00-ed8a-11e9-8898-4bcdda8760ae.png">
(worked as I expected)
