### PR TITLE
Read csrftoken from DOM if no cookie is set

### DIFF
--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -3,8 +3,11 @@
   // Parse the cookie value for a CSRF token
   var csrftoken;
   var cookies = ('; ' + document.cookie).split('; csrftoken=');
-  if (cookies.length == 2)
+  if (cookies.length == 2) {
     csrftoken = cookies.pop().split(';').shift();
+  } else {
+    csrftoken = document.querySelector("[name=csrfmiddlewaretoken]").value;
+  }
 
   // Collect the URL parameters
   var parameters = {};

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -31,6 +31,7 @@ add "&raw" to the end of the URL within a browser.
           crossorigin="anonymous"></script>
 </head>
 <body>
+  {% csrf_token %}
   <script src="{% static 'graphene_django/graphiql.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #307 and #786 
This is based on #308 (closed, unmerged).
If `CSRF_USE_SESSIONS` is used there will be no CSRF cookie. In this case the cookie will be read from an hidden input element in the DOM.