### PR TITLE
Fix typo in exclude type checking test

### DIFF
--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -315,7 +315,7 @@ def test_django_objecttype_fields_exclude_type_checking():
         class Reporter2(DjangoObjectType):
             class Meta:
                 model = ReporterModel
-                fields = "foo"
+                exclude = "foo"
 
 
 class TestDjangoObjectType:


### PR DESCRIPTION
This is a tiny tests fix for typo from #691.