### PR TITLE
Adding support for disabling enum creation on SerializerMutation

### DIFF
--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -19,7 +19,13 @@ class SerializerMutationOptions(MutationOptions):
     serializer_class = None
 
 
-def fields_for_serializer(serializer, only_fields, exclude_fields, is_input=False):
+def fields_for_serializer(
+    serializer,
+    only_fields,
+    exclude_fields,
+    is_input=False,
+    convert_choices_to_enum=True,
+):
     fields = OrderedDict()
     for name, field in serializer.fields.items():
         is_not_in_only = only_fields and name not in only_fields
@@ -34,7 +40,9 @@ def fields_for_serializer(serializer, only_fields, exclude_fields, is_input=Fals
         if is_not_in_only or is_excluded:
             continue
 
-        fields[name] = convert_serializer_field(field, is_input=is_input)
+        fields[name] = convert_serializer_field(
+            field, is_input=is_input, convert_choices_to_enum=convert_choices_to_enum
+        )
     return fields
 
 
@@ -55,6 +63,7 @@ class SerializerMutation(ClientIDMutation):
         model_operations=("create", "update"),
         only_fields=(),
         exclude_fields=(),
+        convert_choices_to_enum=True,
         **options
     ):
 
@@ -74,10 +83,18 @@ class SerializerMutation(ClientIDMutation):
             lookup_field = model_class._meta.pk.name
 
         input_fields = fields_for_serializer(
-            serializer, only_fields, exclude_fields, is_input=True
+            serializer,
+            only_fields,
+            exclude_fields,
+            is_input=True,
+            convert_choices_to_enum=convert_choices_to_enum,
         )
         output_fields = fields_for_serializer(
-            serializer, only_fields, exclude_fields, is_input=False
+            serializer,
+            only_fields,
+            exclude_fields,
+            is_input=False,
+            convert_choices_to_enum=convert_choices_to_enum,
         )
 
         _meta = SerializerMutationOptions(cls)

--- a/graphene_django/rest_framework/serializer_converter.py
+++ b/graphene_django/rest_framework/serializer_converter.py
@@ -19,14 +19,17 @@ def get_graphene_type_from_serializer_field(field):
     )
 
 
-def convert_serializer_field(field, is_input=True):
+def convert_serializer_field(field, is_input=True, convert_choices_to_enum=True):
     """
     Converts a django rest frameworks field to a graphql field
     and marks the field as required if we are creating an input type
     and the field itself is required
     """
 
-    graphql_type = get_graphene_type_from_serializer_field(field)
+    if isinstance(field, serializers.ChoiceField) and not convert_choices_to_enum:
+        graphql_type = graphene.String
+    else:
+        graphql_type = get_graphene_type_from_serializer_field(field)
 
     args = []
     kwargs = {"description": field.help_text, "required": is_input and field.required}

--- a/graphene_django/rest_framework/tests/test_field_converter.py
+++ b/graphene_django/rest_framework/tests/test_field_converter.py
@@ -10,7 +10,9 @@ from ..serializer_converter import convert_serializer_field
 from ..types import DictType
 
 
-def _get_type(rest_framework_field, is_input=True, **kwargs):
+def _get_type(
+    rest_framework_field, is_input=True, convert_choices_to_enum=True, **kwargs
+):
     # prevents the following error:
     # AssertionError: The `source` argument is not meaningful when applied to a `child=` field.
     # Remove `source=` from the field declaration.
@@ -21,7 +23,9 @@ def _get_type(rest_framework_field, is_input=True, **kwargs):
 
     field = rest_framework_field(**kwargs)
 
-    return convert_serializer_field(field, is_input=is_input)
+    return convert_serializer_field(
+        field, is_input=is_input, convert_choices_to_enum=convert_choices_to_enum
+    )
 
 
 def assert_conversion(rest_framework_field, graphene_field, **kwargs):
@@ -71,6 +75,16 @@ def test_should_choice_convert_enum():
     assert field._meta.enum.__members__["H"].description == "Hello"
     assert field._meta.enum.__members__["W"].value == "w"
     assert field._meta.enum.__members__["W"].description == "World"
+
+
+def test_should_choice_convert_string_if_enum_disabled():
+    assert_conversion(
+        serializers.ChoiceField,
+        graphene.String,
+        choices=[("h", "Hello"), ("w", "World")],
+        source="word",
+        convert_choices_to_enum=False,
+    )
 
 
 def test_should_base_field_convert_string():


### PR DESCRIPTION
A workaround for #785 --

Appropriately, `DjangoObjectType` supports a `convert_choices_to_enum` which disables the creation of GraphQL `Enum` types for every `ChoiceField` on a model.

However, `SerializerMutation` (similarly a subclass of `ObjectType` and registered in the GQL schema) does not support such a flag, and forces creating an `Enum` for every `ChoiceField`. This behavior can be undesirable because it can trigger a duplicate type registration error `Found different types with the same name in the schema:`.

For consistency's sake, a flag to disable the `Enum` creation should be added to the `SerializerMutation`; this commit implements such changes.

Sidenote --
In my sandbox, this error actually triggered even when the ChoiceField was only registered one single time, on one single Mutation, and not at all present in the `DjangoObjectType`, which leads me to believe that the `SerializerMutation`'s `Enum` definition is colliding with itself?

There's actually 0% test coverage for the current existing behavior of creating `Enums` for ` SerializerMutation` because [none of these tests](https://github.com/graphql-python/graphene-django/tree/master/graphene_django/rest_framework/tests) actually implement any `Model` with a `ChoicesField`; the test coverage stops at ensuring the automatic type conversion returns a proper value (and I added a second test for my branching logic). I hesitate to suggest it, but it seems that in the current implementation of `Enums` in `SerializerMutations`, simply adding a SerializerMutation with any ChoicesField to a schema might be enough to throw the error?

I might have time to dig deeper into that, but for now, here's an effective and reasonable bandaid.