### PR TITLE
resolve django encoding deprecation warnings

### DIFF
--- a/graphene_django/debug/sql/tracking.py
+++ b/graphene_django/debug/sql/tracking.py
@@ -6,7 +6,7 @@ from threading import local
 from time import time
 
 import six
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from .types import DjangoDebugSQL
 
@@ -78,7 +78,7 @@ class NormalCursorWrapper(object):
 
     def _quote_expr(self, element):
         if isinstance(element, six.string_types):
-            return "'%s'" % force_text(element).replace("'", "''")
+            return "'%s'" % force_str(element).replace("'", "''")
         else:
             return repr(element)
 
@@ -91,7 +91,7 @@ class NormalCursorWrapper(object):
 
     def _decode(self, param):
         try:
-            return force_text(param, strings_only=True)
+            return force_str(param, strings_only=True)
         except UnicodeDecodeError:
             return "(encoded string)"
 


### PR DESCRIPTION
```
  .../graphene_django/debug/sql/tracking.py:81: RemovedInDjango40Warning: force_text() is deprecated in favor of force_str().
    return "'%s'" % force_text(element).replace("'", "''")
```
https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.encoding.force_text

Get rid of more deprecated function calls (see #847), which are spamming into my test suite warnings :)