### PR TITLE
Fix force_str deprecation warning

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from django.db import models
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from graphene import (
     ID,
@@ -30,7 +30,7 @@ singledispatch = import_single_dispatch()
 
 
 def convert_choice_name(name):
-    name = to_const(force_text(name))
+    name = to_const(force_str(name))
     try:
         assert_valid_name(name)
     except AssertionError:


### PR DESCRIPTION
`/usr/local/lib/python3.7/site-packages/graphene_django/converter.py:33: RemovedInDjango40Warning: force_text() is deprecated in favor of force_str().`

https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.encoding.force_str