### PR TITLE
Add options to override how Django Choice fields are converted to Enums

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -140,3 +140,32 @@ Default: ``False``
    #         'messages': ['This field is required.'],
    #     }
    # ]
+
+
+``DJANGO_CHOICE_FIELD_ENUM_V3_NAMING``
+--------------------------------------
+
+Set to ``True`` to use the new naming format for the auto generated Enum types from Django choice fields. The new format looks like this: ``DjangoModel{app_label}{object_name}{field_name}Choices``
+
+Default: ``False``
+
+
+``DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME``
+--------------------------------------
+
+Set to a function that takes the Django choice field and returns a string to completely customise the naming for the Enum type.
+
+If set to a function then the ``DJANGO_CHOICE_FIELD_ENUM_V3_NAMING`` setting is ignored.
+
+Default: ``None``
+
+.. code:: python
+
+   def enum_naming(field):
+      if isinstance(field.model, User):
+         return f"CustomUserEnum{field.name.title()}"
+      return f"CustomEnum{field.name.title()}"
+
+   GRAPHENE = {
+      'DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME': enum_naming
+   }

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -145,7 +145,7 @@ Default: ``False``
 ``DJANGO_CHOICE_FIELD_ENUM_V3_NAMING``
 --------------------------------------
 
-Set to ``True`` to use the new naming format for the auto generated Enum types from Django choice fields. The new format looks like this: ``DjangoModel{app_label}{object_name}{field_name}Choices``
+Set to ``True`` to use the new naming format for the auto generated Enum types from Django choice fields. The new format looks like this: ``{app_label}{object_name}{field_name}Choices``
 
 Default: ``False``
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -153,7 +153,7 @@ Default: ``False``
 ``DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME``
 --------------------------------------
 
-Set to a function that takes the Django choice field and returns a string to completely customise the naming for the Enum type.
+Define the path of a function that takes the Django choice field and returns a string to completely customise the naming for the Enum type.
 
 If set to a function then the ``DJANGO_CHOICE_FIELD_ENUM_V3_NAMING`` setting is ignored.
 
@@ -161,11 +161,12 @@ Default: ``None``
 
 .. code:: python
 
+   # myapp.utils
    def enum_naming(field):
       if isinstance(field.model, User):
          return f"CustomUserEnum{field.name.title()}"
       return f"CustomEnum{field.name.title()}"
 
    GRAPHENE = {
-      'DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME': enum_naming
+      'DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME': "myapp.utils.enum_naming"
    }

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -75,7 +75,7 @@ def generate_enum_name(django_model_meta, field):
     ):
         name = graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME(field)
     elif graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING is True:
-        name = "DjangoModel{app_label}{object_name}{field_name}Choices".format(
+        name = "{app_label}{object_name}{field_name}Choices".format(
             app_label=to_camel_case(django_model_meta.app_label.title()),
             object_name=django_model_meta.object_name,
             field_name=to_camel_case(field.name.title()),

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -70,7 +70,7 @@ def convert_choices_to_named_enum_with_descriptions(name, choices):
 
 
 def generate_enum_name(django_model_meta, field):
-    if graphene_settings.CHOICES_TO_ENUM_UNIQUE_TYPE_NAME is True:
+    if graphene_settings.CHOICES_TO_ENUM_V3_NAMING is True:
         name = "DjangoModel{app_label}{object_name}{field_name}Choices".format(
             app_label=to_camel_case(django_model_meta.app_label.title()),
             object_name=django_model_meta.object_name,

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -70,7 +70,11 @@ def convert_choices_to_named_enum_with_descriptions(name, choices):
 
 
 def generate_enum_name(django_model_meta, field):
-    if graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING is True:
+    if graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME and callable(
+        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME
+    ):
+        name = graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME(field)
+    elif graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING is True:
         name = "DjangoModel{app_label}{object_name}{field_name}Choices".format(
             app_label=to_camel_case(django_model_meta.app_label.title()),
             object_name=django_model_meta.object_name,

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -69,16 +69,15 @@ def convert_choices_to_named_enum_with_descriptions(name, choices):
     return Enum(name, list(named_choices), type=EnumWithDescriptionsType)
 
 
-def generate_enum_name(django_model, field):
-    meta = django_model._meta
+def generate_enum_name(django_model_meta, field):
     if graphene_settings.CHOICES_TO_ENUM_UNIQUE_TYPE_NAME is True:
         name = "DjangoModel{app_label}{object_name}{field_name}Choices".format(
-            app_label=to_camel_case(meta.app_label).capitalize(),
-            object_name=meta.object_name,
-            field_name=to_camel_case(field.name).capitalize(),
+            app_label=to_camel_case(django_model_meta.app_label.title()),
+            object_name=django_model_meta.object_name,
+            field_name=to_camel_case(field.name.title()),
         )
     else:
-        name = to_camel_case("{}_{}".format(meta.object_name, field.name))
+        name = to_camel_case("{}_{}".format(django_model_meta.object_name, field.name))
     return name
 
 
@@ -91,7 +90,7 @@ def convert_django_field_with_choices(
             return converted
     choices = getattr(field, "choices", None)
     if choices and convert_choices_to_enum:
-        name = generate_enum_name(field.model, field)
+        name = generate_enum_name(field.model._meta, field)
         enum = convert_choices_to_named_enum_with_descriptions(name, choices)
         required = not (field.blank or field.null)
         converted = enum(description=field.help_text, required=required)

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -81,6 +81,13 @@ def generate_enum_name(django_model_meta, field):
     return name
 
 
+def convert_choice_field_to_enum(field, name=None):
+    if name is None:
+        name = generate_enum_name(field.model._meta, field)
+    choices = field.choices
+    return convert_choices_to_named_enum_with_descriptions(name, choices)
+
+
 def convert_django_field_with_choices(
     field, registry=None, convert_choices_to_enum=True
 ):
@@ -90,8 +97,7 @@ def convert_django_field_with_choices(
             return converted
     choices = getattr(field, "choices", None)
     if choices and convert_choices_to_enum:
-        name = generate_enum_name(field.model._meta, field)
-        enum = convert_choices_to_named_enum_with_descriptions(name, choices)
+        enum = convert_choice_field_to_enum(field)
         required = not (field.blank or field.null)
         converted = enum(description=field.help_text, required=required)
     else:

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -70,7 +70,7 @@ def convert_choices_to_named_enum_with_descriptions(name, choices):
 
 
 def generate_enum_name(django_model_meta, field):
-    if graphene_settings.CHOICES_TO_ENUM_V3_NAMING is True:
+    if graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING is True:
         name = "DjangoModel{app_label}{object_name}{field_name}Choices".format(
             app_label=to_camel_case(django_model_meta.app_label.title()),
             object_name=django_model_meta.object_name,

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from django.db import models
 from django.utils.encoding import force_str
+from django.utils.module_loading import import_string
 
 from graphene import (
     ID,
@@ -70,10 +71,12 @@ def convert_choices_to_named_enum_with_descriptions(name, choices):
 
 
 def generate_enum_name(django_model_meta, field):
-    if graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME and callable(
-        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME
-    ):
-        name = graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME(field)
+    if graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME:
+        # Try and import custom function
+        custom_func = import_string(
+            graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME
+        )
+        name = custom_func(field)
     elif graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING is True:
         name = "{app_label}{object_name}{field_name}Choices".format(
             app_label=to_camel_case(django_model_meta.app_label.title()),

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -36,8 +36,8 @@ DEFAULTS = {
     # Max items returned in ConnectionFields / FilterConnectionFields
     "RELAY_CONNECTION_MAX_LIMIT": 100,
     "CAMELCASE_ERRORS": False,
-    # Set to True to enable unique naming for choice field Enum's
-    "CHOICES_TO_ENUM_UNIQUE_TYPE_NAME": False,
+    # Set to True to enable v3 naming convention for choice field Enum's
+    "CHOICES_TO_ENUM_V3_NAMING": False,
 }
 
 if settings.DEBUG:

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -37,7 +37,7 @@ DEFAULTS = {
     "RELAY_CONNECTION_MAX_LIMIT": 100,
     "CAMELCASE_ERRORS": False,
     # Set to True to enable v3 naming convention for choice field Enum's
-    "CHOICES_TO_ENUM_V3_NAMING": False,
+    "DJANGO_CHOICE_FIELD_ENUM_V3_NAMING": False,
 }
 
 if settings.DEBUG:

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -36,6 +36,8 @@ DEFAULTS = {
     # Max items returned in ConnectionFields / FilterConnectionFields
     "RELAY_CONNECTION_MAX_LIMIT": 100,
     "CAMELCASE_ERRORS": False,
+    # Set to True to enable unique naming for choice field Enum's
+    "CHOICES_TO_ENUM_UNIQUE_TYPE_NAME": False,
 }
 
 if settings.DEBUG:

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -38,6 +38,7 @@ DEFAULTS = {
     "CAMELCASE_ERRORS": False,
     # Set to True to enable v3 naming convention for choice field Enum's
     "DJANGO_CHOICE_FIELD_ENUM_V3_NAMING": False,
+    "DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME": None,
 }
 
 if settings.DEBUG:

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -335,7 +335,7 @@ def test_should_postgres_range_convert_list():
 
 def test_generate_enum_name():
     MockDjangoModelMeta = namedtuple("DjangoMeta", ["app_label", "object_name"])
-    graphene_settings.CHOICES_TO_ENUM_UNIQUE_TYPE_NAME = True
+    graphene_settings.CHOICES_TO_ENUM_V3_NAMING = True
 
     # Simple case
     field = graphene.Field(graphene.String, name="type")
@@ -352,4 +352,4 @@ def test_generate_enum_name():
         == "DjangoModelSomeLongAppNameSomeObjectFizzBuzzChoices"
     )
 
-    graphene_settings.CHOICES_TO_ENUM_UNIQUE_TYPE_NAME = False
+    graphene_settings.CHOICES_TO_ENUM_V3_NAMING = False

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -335,7 +335,7 @@ def test_should_postgres_range_convert_list():
 
 def test_generate_enum_name():
     MockDjangoModelMeta = namedtuple("DjangoMeta", ["app_label", "object_name"])
-    graphene_settings.CHOICES_TO_ENUM_V3_NAMING = True
+    graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = True
 
     # Simple case
     field = graphene.Field(graphene.String, name="type")
@@ -352,4 +352,4 @@ def test_generate_enum_name():
         == "DjangoModelSomeLongAppNameSomeObjectFizzBuzzChoices"
     )
 
-    graphene_settings.CHOICES_TO_ENUM_V3_NAMING = False
+    graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = False

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -1,4 +1,5 @@
 import pytest
+from collections import namedtuple
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from graphene import NonNull
@@ -10,9 +11,14 @@ from graphene.types.datetime import DateTime, Date, Time
 from graphene.types.json import JSONString
 
 from ..compat import JSONField, ArrayField, HStoreField, RangeField, MissingType
-from ..converter import convert_django_field, convert_django_field_with_choices
+from ..converter import (
+    convert_django_field,
+    convert_django_field_with_choices,
+    generate_enum_name,
+)
 from ..registry import Registry
 from ..types import DjangoObjectType
+from ..settings import graphene_settings
 from .models import Article, Film, FilmDetails, Reporter
 
 
@@ -325,3 +331,25 @@ def test_should_postgres_range_convert_list():
     assert isinstance(field.type, graphene.NonNull)
     assert isinstance(field.type.of_type, graphene.List)
     assert field.type.of_type.of_type == graphene.Int
+
+
+def test_generate_enum_name():
+    MockDjangoModelMeta = namedtuple("DjangoMeta", ["app_label", "object_name"])
+    graphene_settings.CHOICES_TO_ENUM_UNIQUE_TYPE_NAME = True
+
+    # Simple case
+    field = graphene.Field(graphene.String, name="type")
+    model_meta = MockDjangoModelMeta(app_label="users", object_name="User")
+    assert generate_enum_name(model_meta, field) == "DjangoModelUsersUserTypeChoices"
+
+    # More complicated multiple work case
+    field = graphene.Field(graphene.String, name="fizz_buzz")
+    model_meta = MockDjangoModelMeta(
+        app_label="some_long_app_name", object_name="SomeObject"
+    )
+    assert (
+        generate_enum_name(model_meta, field)
+        == "DjangoModelSomeLongAppNameSomeObjectFizzBuzzChoices"
+    )
+
+    graphene_settings.CHOICES_TO_ENUM_UNIQUE_TYPE_NAME = False

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -340,7 +340,7 @@ def test_generate_enum_name():
     # Simple case
     field = graphene.Field(graphene.String, name="type")
     model_meta = MockDjangoModelMeta(app_label="users", object_name="User")
-    assert generate_enum_name(model_meta, field) == "DjangoModelUsersUserTypeChoices"
+    assert generate_enum_name(model_meta, field) == "UsersUserTypeChoices"
 
     # More complicated multiple work case
     field = graphene.Field(graphene.String, name="fizz_buzz")
@@ -349,7 +349,7 @@ def test_generate_enum_name():
     )
     assert (
         generate_enum_name(model_meta, field)
-        == "DjangoModelSomeLongAppNameSomeObjectFizzBuzzChoices"
+        == "SomeLongAppNameSomeObjectFizzBuzzChoices"
     )
 
     graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = False

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -388,6 +388,10 @@ def test_django_objecttype_exclude_fields_exist_on_model():
     assert len(record) == 0
 
 
+def custom_enum_name(field):
+    return "CustomEnum{}".format(field.name.title())
+
+
 class TestDjangoObjectType:
     @pytest.fixture
     def PetModel(self):
@@ -532,10 +536,9 @@ class TestDjangoObjectType:
         graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = False
 
     def test_django_objecttype_choices_custom_enum_name(self, PetModel):
-        def custom_name(field):
-            return "CustomEnum{}".format(field.name.title())
-
-        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME = custom_name
+        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME = (
+            "graphene_django.tests.test_types.custom_enum_name"
+        )
 
         class PetModelKind(DjangoObjectType):
             class Meta:
@@ -553,14 +556,14 @@ class TestDjangoObjectType:
           query: Query
         }
 
-        enum DjangoModelTestsPetModelKindChoices {
+        enum CustomEnumKind {
           CAT
           DOG
         }
 
         type PetModelKind {
           id: ID!
-          kind: DjangoModelTestsPetModelKindChoices!
+          kind: CustomEnumKind!
         }
 
         type Query {

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -533,7 +533,7 @@ class TestDjangoObjectType:
 
     def test_django_objecttype_choices_custom_enum_name(self, PetModel):
         def custom_name(field):
-            return f"CustomEnum{field.name.title()}"
+            return "CustomEnum{}".format(field.name.title())
 
         graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME = custom_name
 

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -514,18 +514,18 @@ class TestDjangoObjectType:
           query: Query
         }
 
-        enum CustomEnumKind {
-          CAT
-          DOG
-        }
-
         type PetModelKind {
           id: ID!
-          kind: CustomEnumKind!
+          kind: TestsPetModelKindChoices!
         }
 
         type Query {
           pet: PetModelKind
+        }
+
+        enum TestsPetModelKindChoices {
+          CAT
+          DOG
         }
         """
         )

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -496,7 +496,7 @@ class TestDjangoObjectType:
         )
 
     def test_django_objecttype_convert_choices_enum_naming_collisions(self, PetModel):
-        graphene_settings.CHOICES_TO_ENUM_UNIQUE_TYPE_NAME = True
+        graphene_settings.CHOICES_TO_ENUM_V3_NAMING = True
 
         class PetModelKind(DjangoObjectType):
             class Meta:
@@ -529,7 +529,7 @@ class TestDjangoObjectType:
         }
         """
         )
-        graphene_settings.CHOICES_TO_ENUM_UNIQUE_TYPE_NAME = False
+        graphene_settings.CHOICES_TO_ENUM_V3_NAMING = False
 
     def test_django_objecttype_choices_override_enum(self, PetModel):
         def convert_choice(model, field_name, **kwargs):

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -514,14 +514,14 @@ class TestDjangoObjectType:
           query: Query
         }
 
-        enum DjangoModelTestsPetModelKindChoices {
+        enum CustomEnumKind {
           CAT
           DOG
         }
 
         type PetModelKind {
           id: ID!
-          kind: DjangoModelTestsPetModelKindChoices!
+          kind: CustomEnumKind!
         }
 
         type Query {
@@ -531,15 +531,13 @@ class TestDjangoObjectType:
         )
         graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = False
 
-    def test_django_objecttype_choices_override_enum(self, PetModel):
-        def convert_choice(model, field_name, **kwargs):
-            return convert_choice_field_to_enum(
-                model._meta.get_field(field_name), **kwargs
-            )
+    def test_django_objecttype_choices_custom_enum_name(self, PetModel):
+        def custom_name(field):
+            return f"CustomEnum{field.name.title()}"
+
+        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME = custom_name
 
         class PetModelKind(DjangoObjectType):
-            kind = Field(convert_choice(PetModel, "kind", name="CustomEnumName"))
-
             class Meta:
                 model = PetModel
                 fields = ["id", "kind"]
@@ -570,3 +568,5 @@ class TestDjangoObjectType:
         }
         """
         )
+
+        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME = None

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -496,7 +496,7 @@ class TestDjangoObjectType:
         )
 
     def test_django_objecttype_convert_choices_enum_naming_collisions(self, PetModel):
-        graphene_settings.CHOICES_TO_ENUM_V3_NAMING = True
+        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = True
 
         class PetModelKind(DjangoObjectType):
             class Meta:
@@ -529,7 +529,7 @@ class TestDjangoObjectType:
         }
         """
         )
-        graphene_settings.CHOICES_TO_ENUM_V3_NAMING = False
+        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = False
 
     def test_django_objecttype_choices_override_enum(self, PetModel):
         def convert_choice(model, field_name, **kwargs):


### PR DESCRIPTION
This PR resolves #185 and #843 by adding 2 new settings to customise the naming of the Enum types generated from Django Choice fields.

* `DJANGO_CHOICE_FIELD_ENUM_V3_NAMING` changes all enum type names to a naming convention that should prevent duplicates. This format will be the default in v3.
* `DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME` allows you to define a custom function to determine what the enum type name should be