### PR TITLE
Only warn if a field doesn't exist on the Django model

### DIFF
--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -320,26 +320,41 @@ def test_django_objecttype_fields_exclude_type_checking():
 
 @with_local_registry
 def test_django_objecttype_fields_exclude_exist_on_model():
-    with pytest.raises(Exception, match=r"Field .* doesn't exist"):
+    with pytest.warns(UserWarning, match=r"Field name .* doesn't exist"):
 
         class Reporter(DjangoObjectType):
             class Meta:
                 model = ReporterModel
                 fields = ["first_name", "foo", "email"]
 
-    with pytest.raises(Exception, match=r"Field .* doesn't exist"):
+    with pytest.warns(UserWarning, match=r"Field name .* doesn't exist"):
 
         class Reporter2(DjangoObjectType):
             class Meta:
                 model = ReporterModel
                 exclude = ["first_name", "foo", "email"]
 
-    with pytest.raises(Exception, match=r".* exists on model .* but it's not a field"):
+    with pytest.warns(
+        UserWarning,
+        match=r"Field name .* exists on Django model .* but it's not a model field",
+    ):
 
         class Reporter3(DjangoObjectType):
             class Meta:
                 model = ReporterModel
                 fields = ["first_name", "some_method", "email"]
+
+    # Don't warn if selecting a custom field
+    with pytest.warns(None) as record:
+
+        class Reporter4(DjangoObjectType):
+            custom_field = String()
+
+            class Meta:
+                model = ReporterModel
+                fields = ["first_name", "custom_field", "email"]
+
+    assert len(record) == 0
 
 
 class TestDjangoObjectType:

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -327,19 +327,12 @@ def test_django_objecttype_fields_exclude_exist_on_model():
                 model = ReporterModel
                 fields = ["first_name", "foo", "email"]
 
-    with pytest.warns(UserWarning, match=r"Field name .* doesn't exist"):
-
-        class Reporter2(DjangoObjectType):
-            class Meta:
-                model = ReporterModel
-                exclude = ["first_name", "foo", "email"]
-
     with pytest.warns(
         UserWarning,
-        match=r"Field name .* exists on Django model .* but it's not a model field",
-    ):
+        match=r"Field name .* matches an attribute on Django model .* but it's not a model field",
+    ) as record:
 
-        class Reporter3(DjangoObjectType):
+        class Reporter2(DjangoObjectType):
             class Meta:
                 model = ReporterModel
                 fields = ["first_name", "some_method", "email"]
@@ -347,7 +340,7 @@ def test_django_objecttype_fields_exclude_exist_on_model():
     # Don't warn if selecting a custom field
     with pytest.warns(None) as record:
 
-        class Reporter4(DjangoObjectType):
+        class Reporter3(DjangoObjectType):
             custom_field = String()
 
             class Meta:


### PR DESCRIPTION
Also don't warn if the field name matches a custom field.

Resolves issues from #842