### PR TITLE
Allow for easier template overrides in graphiql

### DIFF
--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -97,6 +97,6 @@
   // Render <GraphiQL /> into the body.
   ReactDOM.render(
     React.createElement(GraphiQL, options),
-    document.getElementsByClassName("editor")[0]
+    document.getElementById("editor")
   );
 })();

--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -97,6 +97,6 @@
   // Render <GraphiQL /> into the body.
   ReactDOM.render(
     React.createElement(GraphiQL, options),
-    document.body
+    document.getElementsByClassName("editor")[0]
   );
 })();

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -10,7 +10,7 @@ add "&raw" to the end of the URL within a browser.
 <html>
 <head>
   <style>
-    html, body {
+    html, body, #editor {
       height: 100%;
       margin: 0;
       overflow: hidden;

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -31,7 +31,7 @@ add "&raw" to the end of the URL within a browser.
           crossorigin="anonymous"></script>
 </head>
 <body>
-  <div class="editor"></div>
+  <div id="editor"></div>
   {% csrf_token %}
   <script src="{% static 'graphene_django/graphiql.js' %}"></script>
 </body>

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -31,6 +31,7 @@ add "&raw" to the end of the URL within a browser.
           crossorigin="anonymous"></script>
 </head>
 <body>
+  <div class="editor"></div>
   {% csrf_token %}
   <script src="{% static 'graphene_django/graphiql.js' %}"></script>
 </body>


### PR DESCRIPTION

Use case: I use https://pypi.org/project/django-impersonate/ to allow testing my API as various users, and it's always handy to have a header which reminds you who you're impersonating.

By making graphiql populate a div rather than body, it's easier to override the template with additional content. Currently graphiql replaces all the content in `body` meaning any other content you add is also removed.