### PR TITLE
Make stalebot less agressive

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,10 @@ daysUntilClose: 14
 exemptLabels:
   - pinned
   - security
+  - 🐛bug
+  - 📖 documentation
+  - help wanted
+  - ✨enhancement
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Stalebot currently only exempt security and pinned issues. I think it makes sense to expand those labels as we have had allot of valid issues that are tagged being marked as stale.

Added the following to exempt labels:

* bug
* documentation
* help wanted
* enhancement