### PR TITLE
Allow defining fields as an empty list

### DIFF
--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -231,6 +231,17 @@ def test_django_objecttype_fields():
 
 
 @with_local_registry
+def test_django_objecttype_fields_empty():
+    class Reporter(DjangoObjectType):
+        class Meta:
+            model = ReporterModel
+            fields = ()
+
+    fields = list(Reporter._meta.fields.keys())
+    assert fields == []
+
+
+@with_local_registry
 def test_django_objecttype_only_fields_and_fields():
     with pytest.raises(Exception):
 

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -35,9 +35,15 @@ def construct_fields(
 
     fields = OrderedDict()
     for name, field in _model_fields:
-        is_not_in_only = only_fields and name not in only_fields
+        is_not_in_only = (
+            only_fields is not None
+            and only_fields != ALL_FIELDS
+            and name not in only_fields
+        )
         # is_already_created = name in options.fields
-        is_excluded = name in exclude_fields  # or is_already_created
+        is_excluded = (
+            exclude_fields is not None and name in exclude_fields
+        )  # or is_already_created
         # https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.ForeignKey.related_query_name
         is_no_backref = str(name).endswith("+")
         if is_not_in_only or is_excluded or is_no_backref:
@@ -65,6 +71,7 @@ def construct_fields(
 def validate_fields(type_, model, fields, only_fields, exclude_fields):
     # Validate the given fields against the model's fields and custom fields
     all_field_names = set(fields.keys())
+    only_fields = only_fields if only_fields is not ALL_FIELDS else ()
     for name in only_fields or ():
         if name in all_field_names:
             continue
@@ -142,10 +149,10 @@ class DjangoObjectType(ObjectType):
         model=None,
         registry=None,
         skip_registry=False,
-        only_fields=(),  # deprecated in favour of `fields`
-        fields=(),
-        exclude_fields=(),  # deprecated in favour of `exclude`
-        exclude=(),
+        only_fields=None,  # deprecated in favour of `fields`
+        fields=None,
+        exclude_fields=None,  # deprecated in favour of `exclude`
+        exclude=None,
         filter_fields=None,
         filterset_class=None,
         connection=None,
@@ -199,9 +206,6 @@ class DjangoObjectType(ObjectType):
                 'The `fields` option must be a list or tuple or "__all__". '
                 "Got %s." % type(fields).__name__
             )
-
-        if fields == ALL_FIELDS:
-            fields = None
 
         # Alias exclude_fields -> exclude
         if exclude_fields and exclude:


### PR DESCRIPTION
I think it makes sense that if the fields list is defined as an empty list on a DjangoObjectType then no model fields will be selected.

Resolves #864 