### PR TITLE
Use actual root/variables/context args of the execute schema function

### DIFF
--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -180,7 +180,7 @@ def test_filter_shortcut_filterset_context():
     }
     """
     schema = Schema(query=Query)
-    result = schema.execute(query, context=context())
+    result = schema.execute(query, context_value=context())
     assert not result.errors
 
     assert len(result.data["contextArticles"]["edges"]) == 1

--- a/graphene_django/forms/tests/test_mutation.py
+++ b/graphene_django/forms/tests/test_mutation.py
@@ -161,7 +161,7 @@ class ModelFormMutationTests(TestCase):
                 }
             }
             """,
-            variables={"pk": pet.pk},
+            variable_values={"pk": pet.pk},
         )
 
         self.assertIs(result.errors, None)

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -274,10 +274,10 @@ class GraphQLView(View):
                 extra_options["executor"] = self.executor
 
             return document.execute(
-                root=self.get_root_value(request),
-                variables=variables,
+                root_value=self.get_root_value(request),
+                variable_values=variables,
                 operation_name=operation_name,
-                context=self.get_context(request),
+                context_value=self.get_context(request),
                 middleware=self.get_middleware(request),
                 **extra_options
             )


### PR DESCRIPTION
Since the version 2.3.0, graphql-core switched to the old arguments for the `execute` function for execution queries to schema. This PR should fix a bunch of deprecation warnings from this method.