### PR TITLE
Exclude read_only fields from input

### DIFF
--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -29,12 +29,13 @@ def fields_for_serializer(
     fields = OrderedDict()
     for name, field in serializer.fields.items():
         is_not_in_only = only_fields and name not in only_fields
-        is_excluded = (
-            name
-            in exclude_fields  # or
-            # name in already_created_fields
-        ) or (
-            field.write_only and not is_input  # don't show write_only fields in Query
+        is_excluded = any(
+            [
+                name in exclude_fields,
+                field.write_only
+                and not is_input,  # don't show write_only fields in Query
+                field.read_only and is_input,  # don't show read_only fields in Input
+            ]
         )
 
         if is_not_in_only or is_excluded:

--- a/graphene_django/rest_framework/tests/test_mutation.py
+++ b/graphene_django/rest_framework/tests/test_mutation.py
@@ -132,6 +132,25 @@ def test_write_only_field_using_extra_kwargs():
     ), "'password' is write_only field and shouldn't be visible"
 
 
+@mark.django_db
+def test_read_only_fields():
+    class ReadOnlyFieldModelSerializer(serializers.ModelSerializer):
+        cool_name = serializers.CharField(read_only=True)
+
+        class Meta:
+            model = MyFakeModelWithPassword
+            fields = ["cool_name", "password"]
+
+    class MyMutation(SerializerMutation):
+        class Meta:
+            serializer_class = ReadOnlyFieldModelSerializer
+
+    assert "password" in MyMutation.Input._meta.fields
+    assert (
+        "cool_name" not in MyMutation.Input._meta.fields
+    ), "'cool_name' is read_only field and shouldn't be on arguments"
+
+
 def test_nested_model():
     class MyFakeModelGrapheneType(DjangoObjectType):
         class Meta:


### PR DESCRIPTION
The field filtering exists only for write_only in Output, this PR adds the opposite, read_only not showing in Input.