### PR TITLE
Improv/documentation fixes

### DIFF
--- a/docs/authorization.rst
+++ b/docs/authorization.rst
@@ -166,7 +166,7 @@ To restrict users from accessing the GraphQL API page the standard Django LoginR
 
 After this, you can use the new ``PrivateGraphQLView`` in the project's URL Configuration file ``url.py``:
 
-For Django 1.9 and below:
+For Django 1.11:
 
 .. code:: python
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Requirements
 
 Graphene-Django currently supports the following versions of Django:
 
-* Django 2.X
+* >= Django 1.11
 
 Installation
 ------------
@@ -31,6 +31,20 @@ Add ``graphene_django`` to the ``INSTALLED_APPS`` in the ``settings.py`` file of
 
 
 We need to add a ``graphql`` URL to the ``urls.py`` of your Django project:
+
+For Django 1.11:
+
+.. code:: python
+
+    from django.conf.urls import url
+    from graphene_django.views import GraphQLView
+
+    urlpatterns = [
+        # ...
+        url(r"graphql", GraphQLView.as_view(graphiql=True)),
+    ]
+
+For Django 2.0 and above:
 
 .. code:: python
 

--- a/docs/tutorial-plain.rst
+++ b/docs/tutorial-plain.rst
@@ -286,7 +286,7 @@ from the command line.
     $ python ./manage.py runserver
 
     Performing system checks...
-    Django version 1.9, using settings 'cookbook.settings'
+    Django version 1.11, using settings 'cookbook.settings'
     Starting development server at http://127.0.0.1:8000/
     Quit the server with CONTROL-C.
 

--- a/docs/tutorial-relay.rst
+++ b/docs/tutorial-relay.rst
@@ -277,7 +277,7 @@ from the command line.
     $ python ./manage.py runserver
 
     Performing system checks...
-    Django version 1.9, using settings 'cookbook.settings'
+    Django version 1.11, using settings 'cookbook.settings'
     Starting development server at http://127.0.0.1:8000/
     Quit the server with CONTROL-C.
 


### PR DESCRIPTION
- Mention support for Django 1.11 in the documentation.
- Replace Django 1.9 with 1.11 as minimum supported Django version.
