### PR TITLE
Adding Django filter as an installed app

### DIFF
--- a/examples/cookbook/cookbook/settings.py
+++ b/examples/cookbook/cookbook/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "graphene_django",
     "cookbook.ingredients.apps.IngredientsConfig",
     "cookbook.recipes.apps.RecipesConfig",
+    "django_filters",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
While trying to figure out how to filter results I came across the reference to the cookbook but there was missing a section that shows that we need to register the app we installed (Django-filters).

Hope this will be useful for me as for others as well. 