### PR TITLE
Documentation missing endpoint explanation

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -3,6 +3,8 @@ Testing API calls with django
 
 If you want to unittest your API calls derive your test case from the class `GraphQLTestCase`.
 
+Your endpoint is set with `GRAPHQL_URL`. The default endpoint is `GRAPHQL_URL="/graphql/"` in `GraphQLTestCase`
+
 Usage:
 
 .. code:: python

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -3,7 +3,7 @@ Testing API calls with django
 
 If you want to unittest your API calls derive your test case from the class `GraphQLTestCase`.
 
-Your endpoint is set with `GRAPHQL_URL`. The default endpoint is `GRAPHQL_URL="/graphql/"` in `GraphQLTestCase`
+Your endpoint is set through the `GRAPHQL_URL` attribute on `GraphQLTestCase`. The default endpoint is `GRAPHQL_URL = "/graphql/"`.
 
 Usage:
 


### PR DESCRIPTION
Add some information about GRAPHQL_URL. Otherwise people run into ERROR 400 problems, if they have a different endpoint.