### PR TITLE
Make tests order independent

### DIFF
--- a/graphene_django/conftest.py
+++ b/graphene_django/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from graphene_django.settings import graphene_settings as gsettings
+
+from .registry import reset_global_registry
+
+
+@pytest.fixture(autouse=True)
+def reset_registry_fixture(db):
+    yield None
+    reset_global_registry()
+
+
+@pytest.fixture()
+def graphene_settings():
+    settings = dict(gsettings.__dict__)
+    yield gsettings
+    gsettings.__dict__ = settings

--- a/graphene_django/debug/tests/test_query.py
+++ b/graphene_django/debug/tests/test_query.py
@@ -1,5 +1,3 @@
-import pytest
-
 import graphene
 from graphene.relay import Node
 from graphene_django import DjangoConnectionField, DjangoObjectType
@@ -11,11 +9,6 @@ from ..types import DjangoDebug
 
 class context(object):
     pass
-
-
-# from examples.starwars_django.models import Character
-
-pytestmark = pytest.mark.django_db
 
 
 def test_should_query_field():

--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -35,9 +35,6 @@ else:
         )
     )
 
-pytestmark.append(pytest.mark.django_db)
-
-
 if DJANGO_FILTER_INSTALLED:
 
     class ArticleNode(DjangoObjectType):

--- a/graphene_django/rest_framework/tests/test_multiple_model_serializers.py
+++ b/graphene_django/rest_framework/tests/test_multiple_model_serializers.py
@@ -1,13 +1,10 @@
-import graphene
-import pytest
 from django.db import models
-from graphene import Schema
 from rest_framework import serializers
 
+import graphene
+from graphene import Schema
 from graphene_django import DjangoObjectType
 from graphene_django.rest_framework.mutation import SerializerMutation
-
-pytestmark = pytest.mark.django_db
 
 
 class MyFakeChildModel(models.Model):

--- a/graphene_django/rest_framework/tests/test_mutation.py
+++ b/graphene_django/rest_framework/tests/test_mutation.py
@@ -1,14 +1,13 @@
 import datetime
 
-from py.test import mark, raises
+from py.test import raises
 from rest_framework import serializers
 
 from graphene import Field, ResolveInfo
 from graphene.types.inputobjecttype import InputObjectType
 
-from ...settings import graphene_settings
 from ...types import DjangoObjectType
-from ..models import MyFakeModel, MyFakeModelWithPassword, MyFakeModelWithDate
+from ..models import MyFakeModel, MyFakeModelWithDate, MyFakeModelWithPassword
 from ..mutation import SerializerMutation
 
 
@@ -99,7 +98,6 @@ def test_exclude_fields():
     assert "created" not in MyMutation.Input._meta.fields
 
 
-@mark.django_db
 def test_write_only_field():
     class WriteOnlyFieldModelSerializer(serializers.ModelSerializer):
         password = serializers.CharField(write_only=True)
@@ -122,7 +120,6 @@ def test_write_only_field():
     ), "'password' is write_only field and shouldn't be visible"
 
 
-@mark.django_db
 def test_write_only_field_using_extra_kwargs():
     class WriteOnlyFieldModelSerializer(serializers.ModelSerializer):
         class Meta:
@@ -144,7 +141,6 @@ def test_write_only_field_using_extra_kwargs():
     ), "'password' is write_only field and shouldn't be visible"
 
 
-@mark.django_db
 def test_read_only_fields():
     class ReadOnlyFieldModelSerializer(serializers.ModelSerializer):
         cool_name = serializers.CharField(read_only=True)
@@ -194,7 +190,6 @@ def test_mutate_and_get_payload_success():
     assert result.errors is None
 
 
-@mark.django_db
 def test_model_add_mutate_and_get_payload_success():
     result = MyModelMutation.mutate_and_get_payload(
         None, mock_info(), **{"cool_name": "Narf"}
@@ -204,7 +199,6 @@ def test_model_add_mutate_and_get_payload_success():
     assert isinstance(result.created, datetime.datetime)
 
 
-@mark.django_db
 def test_model_update_mutate_and_get_payload_success():
     instance = MyFakeModel.objects.create(cool_name="Narf")
     result = MyModelMutation.mutate_and_get_payload(
@@ -214,7 +208,6 @@ def test_model_update_mutate_and_get_payload_success():
     assert result.cool_name == "New Narf"
 
 
-@mark.django_db
 def test_model_partial_update_mutate_and_get_payload_success():
     instance = MyFakeModel.objects.create(cool_name="Narf")
     result = MyModelMutation.mutate_and_get_payload(
@@ -224,7 +217,6 @@ def test_model_partial_update_mutate_and_get_payload_success():
     assert result.cool_name == "Narf"
 
 
-@mark.django_db
 def test_model_invalid_update_mutate_and_get_payload_success():
     class InvalidModelMutation(SerializerMutation):
         class Meta:
@@ -239,7 +231,6 @@ def test_model_invalid_update_mutate_and_get_payload_success():
     assert '"id" required' in str(exc.value)
 
 
-@mark.django_db
 def test_perform_mutate_success():
     class MyMethodMutation(SerializerMutation):
         class Meta:
@@ -272,11 +263,10 @@ def test_model_mutate_and_get_payload_error():
     assert len(result.errors) > 0
 
 
-def test_mutation_error_camelcased():
+def test_mutation_error_camelcased(graphene_settings):
     graphene_settings.CAMELCASE_ERRORS = True
     result = MyModelMutation.mutate_and_get_payload(None, mock_info(), **{})
     assert result.errors[0].field == "coolName"
-    graphene_settings.CAMELCASE_ERRORS = False
 
 
 def test_invalid_serializer_operations():

--- a/graphene_django/tests/test_command.py
+++ b/graphene_django/tests/test_command.py
@@ -8,7 +8,7 @@ from graphene import ObjectType, Schema, String
 
 
 @patch("graphene_django.management.commands.graphql_schema.Command.save_json_file")
-def test_generate_json_file_on_call_graphql_schema(savefile_mock, settings):
+def test_generate_json_file_on_call_graphql_schema(savefile_mock):
     out = StringIO()
     management.call_command("graphql_schema", schema="", stdout=out)
     assert "Successfully dumped GraphQL schema to schema.json" in out.getvalue()

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -1,16 +1,17 @@
-import pytest
 from collections import namedtuple
+
+import pytest
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from graphene import NonNull
 from py.test import raises
 
 import graphene
+from graphene import NonNull
 from graphene.relay import ConnectionField, Node
-from graphene.types.datetime import DateTime, Date, Time
+from graphene.types.datetime import Date, DateTime, Time
 from graphene.types.json import JSONString
 
-from ..compat import JSONField, ArrayField, HStoreField, RangeField, MissingType
+from ..compat import ArrayField, HStoreField, JSONField, MissingType, RangeField
 from ..converter import (
     convert_django_field,
     convert_django_field_with_choices,
@@ -18,9 +19,7 @@ from ..converter import (
 )
 from ..registry import Registry
 from ..types import DjangoObjectType
-from ..settings import graphene_settings
 from .models import Article, Film, FilmDetails, Reporter
-
 
 # from graphene.core.types.custom_scalars import DateTime, Time, JSONString
 
@@ -333,7 +332,7 @@ def test_should_postgres_range_convert_list():
     assert field.type.of_type.of_type == graphene.Int
 
 
-def test_generate_enum_name():
+def test_generate_enum_name(graphene_settings):
     MockDjangoModelMeta = namedtuple("DjangoMeta", ["app_label", "object_name"])
     graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = True
 
@@ -351,5 +350,3 @@ def test_generate_enum_name():
         generate_enum_name(model_meta, field)
         == "SomeLongAppNameSomeObjectFizzBuzzChoices"
     )
-
-    graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = False

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -10,7 +10,6 @@ from .models import Article as ArticleModel
 from .models import Reporter as ReporterModel
 
 
-@pytest.mark.django_db
 class TestDjangoListField:
     def test_only_django_object_types(self):
         class TestType(ObjectType):

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -1,25 +1,20 @@
-import base64
 import datetime
 
 import pytest
 from django.db import models
+from django.db.models import Q
 from django.utils.functional import SimpleLazyObject
+from graphql_relay import to_global_id
 from py.test import raises
 
-from django.db.models import Q
-
-from graphql_relay import to_global_id
 import graphene
 from graphene.relay import Node
 
-from ..utils import DJANGO_FILTER_INSTALLED
-from ..compat import MissingType, JSONField
+from ..compat import JSONField, MissingType
 from ..fields import DjangoConnectionField
 from ..types import DjangoObjectType
-from ..settings import graphene_settings
-from .models import Article, CNNReporter, Reporter, Film, FilmDetails
-
-pytestmark = pytest.mark.django_db
+from ..utils import DJANGO_FILTER_INSTALLED
+from .models import Article, CNNReporter, Film, FilmDetails, Reporter
 
 
 def test_should_query_only_fields():
@@ -147,9 +142,6 @@ def test_should_query_postgres_fields():
 
 
 def test_should_node():
-    # reset_global_registry()
-    # Node._meta.registry = get_global_registry()
-
     class ReporterNode(DjangoObjectType):
         class Meta:
             model = Reporter
@@ -588,7 +580,7 @@ def test_should_query_node_multiple_filtering():
     assert result.data == expected
 
 
-def test_should_enforce_first_or_last():
+def test_should_enforce_first_or_last(graphene_settings):
     graphene_settings.RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST = True
 
     class ReporterType(DjangoObjectType):
@@ -627,7 +619,7 @@ def test_should_enforce_first_or_last():
     assert result.data == expected
 
 
-def test_should_error_if_first_is_greater_than_max():
+def test_should_error_if_first_is_greater_than_max(graphene_settings):
     graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 100
 
     class ReporterType(DjangoObjectType):
@@ -667,10 +659,8 @@ def test_should_error_if_first_is_greater_than_max():
     )
     assert result.data == expected
 
-    graphene_settings.RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST = False
 
-
-def test_should_error_if_last_is_greater_than_max():
+def test_should_error_if_last_is_greater_than_max(graphene_settings):
     graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 100
 
     class ReporterType(DjangoObjectType):
@@ -709,8 +699,6 @@ def test_should_error_if_last_is_greater_than_max():
         "exceeds the `last` limit of 100 records."
     )
     assert result.data == expected
-
-    graphene_settings.RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST = False
 
 
 def test_should_query_promise_connectionfields():

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -9,13 +9,9 @@ from graphene import Connection, Field, Interface, ObjectType, Schema, String
 from graphene.relay import Node
 
 from .. import registry
-from ..settings import graphene_settings
 from ..types import DjangoObjectType, DjangoObjectTypeOptions
-from ..converter import convert_choice_field_to_enum
 from .models import Article as ArticleModel
 from .models import Reporter as ReporterModel
-
-registry.reset_global_registry()
 
 
 class Reporter(DjangoObjectType):
@@ -198,7 +194,6 @@ type RootQuery {
 def with_local_registry(func):
     def inner(*args, **kwargs):
         old = registry.get_global_registry()
-        registry.reset_global_registry()
         try:
             retval = func(*args, **kwargs)
         except Exception as e:
@@ -499,7 +494,9 @@ class TestDjangoObjectType:
         """
         )
 
-    def test_django_objecttype_convert_choices_enum_naming_collisions(self, PetModel):
+    def test_django_objecttype_convert_choices_enum_naming_collisions(
+        self, PetModel, graphene_settings
+    ):
         graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = True
 
         class PetModelKind(DjangoObjectType):
@@ -533,9 +530,10 @@ class TestDjangoObjectType:
         }
         """
         )
-        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = False
 
-    def test_django_objecttype_choices_custom_enum_name(self, PetModel):
+    def test_django_objecttype_choices_custom_enum_name(
+        self, PetModel, graphene_settings
+    ):
         graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME = (
             "graphene_django.tests.test_types.custom_enum_name"
         )
@@ -571,5 +569,3 @@ class TestDjangoObjectType:
         }
         """
         )
-
-        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME = None


### PR DESCRIPTION
* Reset the global registry after each test (teardown)

* Create a settings fixtures that returns graphene_settings and resets the graphene_settings after use (teardown)

* Convert test_mutation tests from unittests.TestCase to pytest

* Convert test_mutation PetType to a pet_type fixtures that reregisters the type

The core change is setup/teardown in conftest.py

https://github.com/graphql-python/graphene-django/blob/a16cebea7c2fb2bb33a5c677e96ad8a0cfe8100d/graphene_django/conftest.py#L8-L18