### PR TITLE
Update django form mutation to more granularly handle input/output fields

### DIFF
--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -63,9 +63,15 @@ DjangoFormMutation
     class MyForm(forms.Form):
         name = forms.CharField()
 
+        def clean(self):
+            self.cleaned_data["constructed_output"] = "an item"
+
     class MyMutation(DjangoFormMutation):
         class Meta:
             form_class = MyForm
+            input_fields = "__all__"
+
+        constructed_output = graphene.String()
 
 ``MyMutation`` will automatically receive an ``input`` argument. This argument should be a ``dict`` where the key is ``name`` and the value is a string.
 

--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -104,8 +104,13 @@ class DjangoFormMutation(BaseDjangoFormMutation):
 
     @classmethod
     def __init_subclass_with_meta__(
-        cls, form_class=None, only_fields=(), exclude_fields=(), 
-        fields=None, exclude=(), input_fields=None,
+        cls,
+        form_class=None,
+        only_fields=(),
+        exclude_fields=(),
+        fields=None,
+        exclude=(),
+        input_fields=None,
         **options
     ):
 
@@ -113,28 +118,33 @@ class DjangoFormMutation(BaseDjangoFormMutation):
             raise Exception("form_class is required for DjangoFormMutation")
 
         form = form_class()
-        if (any([fields, exclude, input_fields])
-             and (only_fields or exclude_fields)):
-            raise Exception("Cannot specify legacy `only_fields` or `exclude_fields` params with"
-                            " `only`, `exclude`, or `input_fields` params")
+        if any([fields, exclude, input_fields]) and (only_fields or exclude_fields):
+            raise Exception(
+                "Cannot specify legacy `only_fields` or `exclude_fields` params with"
+                " `only`, `exclude`, or `input_fields` params"
+            )
         if only_fields or exclude_fields:
             warnings.warn(
                 "only_fields/exclude_fields have been deprecated, use "
                 "input_fields or only/exclude (for output fields)"
                 "instead",
-                DeprecationWarning
+                DeprecationWarning,
             )
         if not fields or exclude:
             warnings.warn(
                 "a future version of graphene-django will require fields or exclude."
                 " Set fields='__all__' to allow all fields through.",
-                DeprecationWarning
+                DeprecationWarning,
             )
         if not input_fields and input_fields is not None:
             input_fields = {}
         else:
-            input_fields = fields_for_form(form, only_fields or input_fields, exclude_fields)
-        output_fields = fields_for_form(form, only_fields or fields, exclude_fields or exclude)
+            input_fields = fields_for_form(
+                form, only_fields or input_fields, exclude_fields
+            )
+        output_fields = fields_for_form(
+            form, only_fields or fields, exclude_fields or exclude
+        )
 
         _meta = DjangoFormMutationOptions(cls)
         _meta.form_class = form_class

--- a/graphene_django/forms/tests/test_mutation.py
+++ b/graphene_django/forms/tests/test_mutation.py
@@ -81,6 +81,7 @@ def test_no_input_fields():
         class Meta:
             form_class = MyForm
             input_fields = []
+
     assert set(MyMutation.Input._meta.fields.keys()) == set(["client_mutation_id"])
 
 
@@ -90,7 +91,7 @@ def test_filtering_input_fields():
             form_class = MyForm
             input_fields = ["text"]
 
-    assert "text" in  MyMutation.Input._meta.fields
+    assert "text" in MyMutation.Input._meta.fields
     assert "another" not in MyMutation.Input._meta.fields
 
 
@@ -99,6 +100,7 @@ def test_select_output_fields():
         class Meta:
             form_class = MyForm
             fields = ["text"]
+
     assert "text" in MyMutation._meta.fields
     assert "another" not in MyMutation._meta.fields
 
@@ -106,8 +108,10 @@ def test_select_output_fields():
 def test_filtering_output_fields_exclude():
     class FormWithWeirdOutput(MyForm):
         """Weird form that has extra cleaned_data we want to expose"""
+
         text = forms.CharField()
         another = forms.CharField(required=False)
+
         def clean(self):
             super(FormWithWeirdOutput, self).clean()
             self.cleaned_data["some_integer"] = 5


### PR DESCRIPTION
Example of how I'd like to change DjangoFormMutation as per #933. I think this should be backwards compatible with the existing one.  Check out docstring on `DjangoFormMutation` for an overview of what the changes (ought to!) do :)

I also tried to add some docs about class behavior.

This still needs a test case and probably to be merged into the public graphene django docs but I figured this'd be good basis for discussion :)

Ultimately this is motivated by me having desire to be able to have a graphql mutation that just returns `clientMutationId` and a single object even tho I'm not using a `DjangoModelFormMutation`.