### PR TITLE
Switch `operation_name` to `operationName` in GraphQLTestCase

### DIFF
--- a/graphene_django/tests/test_utils.py
+++ b/graphene_django/tests/test_utils.py
@@ -40,7 +40,7 @@ def test_camelize():
 @patch("graphene_django.utils.testing.Client.post")
 def test_graphql_test_case_op_name(post_mock):
     """
-    Test that `GraphQLTestCase.query()`'s `op_name` argument produces an `operationName` key.
+    Test that `GraphQLTestCase.query()`'s `op_name` argument produces an `operationName` field.
     """
 
     class TestClass(GraphQLTestCase):
@@ -50,7 +50,8 @@ def test_graphql_test_case_op_name(post_mock):
     tc.setUpClass()
     tc.query("query { }", op_name="QueryName")
     body = json.loads(post_mock.call_args.args[1])
+    # `operationName` field from https://graphql.org/learn/serving-over-http/#post-request
     assert (
         "operationName",
         "QueryName",
-    ) in body.items(), "Key 'operationName' is not present in the final request."
+    ) in body.items(), "Field 'operationName' is not present in the final request."

--- a/graphene_django/tests/test_utils.py
+++ b/graphene_django/tests/test_utils.py
@@ -46,6 +46,9 @@ def test_graphql_test_case_op_name(post_mock):
     class TestClass(GraphQLTestCase):
         GRAPHQL_SCHEMA = True
 
+        def runTest(self):
+            pass
+
     tc = TestClass()
     tc.setUpClass()
     tc.query("query { }", op_name="QueryName")

--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -32,20 +32,20 @@ class GraphQLTestCase(TestCase):
                                 supply the op_name.  For annon queries ("{ ... }"),
                                 should be None (default).
             input_data (dict) - If provided, the $input variable in GraphQL will be set
-                                to this value. If both ``input_data`` and ``variables``, 
+                                to this value. If both ``input_data`` and ``variables``,
                                 are provided, the ``input`` field in the ``variables``
                                 dict will be overwritten with this value.
             variables (dict)  - If provided, the "variables" field in GraphQL will be
                                 set to this value.
             headers (dict)    - If provided, the headers in POST request to GRAPHQL_URL
-                                will be set to this value. 
+                                will be set to this value.
 
         Returns:
             Response object from client
         """
         body = {"query": query}
         if op_name:
-            body["operation_name"] = op_name
+            body["operationName"] = op_name
         if variables:
             body["variables"] = variables
         if input_data:


### PR DESCRIPTION
The [documentation for serving GraphQL over HTTP](https://graphql.org/learn/serving-over-http/#post-request) recommends that the operation name be specified by an `operationName` parameter.

The `GraphQLTestCase.query()` method ends up creating a request that uses snake_case `operation_name` instead. This PR addresses that.

I wasn't sure how to write a complete test for this using GraphQLTestCase itself since it requires a database, so I settled for just testing the arguments that were used for `Client.post()`.