### PR TITLE
Disable system checks for graphql_schema management command

### DIFF
--- a/graphene_django/management/commands/graphql_schema.py
+++ b/graphene_django/management/commands/graphql_schema.py
@@ -48,6 +48,7 @@ class CommandArguments(BaseCommand):
 class Command(CommandArguments):
     help = "Dump Graphene schema as a JSON or GraphQL file"
     can_import_settings = True
+    requires_system_checks = False
 
     def save_json_file(self, out, schema_dict, indent):
         with open(out, "w") as outfile:


### PR DESCRIPTION
I find myself generating the schema as part of CI regularly (to avoid having to check a generated file into source control) but some pipelines don't have access to a database and the system checks will always fail as a result.

To combat this I propose [system checks are disabled](https://docs.djangoproject.com/en/dev/howto/custom-management-commands/#django.core.management.BaseCommand.requires_system_checks) for the command.