### PR TITLE
Make tests order independent (v3)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE = django_test_settings

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,7 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
+
+[tool:pytest]
+DJANGO_SETTINGS_MODULE = django_test_settings
+addopts = --random-order

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ rest_framework_require = ["djangorestframework>=3.6.3"]
 tests_require = [
     "pytest>=3.6.3",
     "pytest-cov",
+    "pytest-random-order",
     "coveralls",
     "mock",
     "pytz",


### PR DESCRIPTION
* Add pytest-random-order to change test-order on each pytest-run

Contains the part that can only be merged on v3