### PR TITLE
Do not access the internals of `SimpleLazyObject`

### DIFF
--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -60,6 +60,31 @@ def test_should_query_simplelazy_objects():
     assert result.data == {"reporter": {"id": "1"}}
 
 
+def test_should_query_wrapped_simplelazy_objects():
+    class ReporterType(DjangoObjectType):
+        class Meta:
+            model = Reporter
+            fields = ("id",)
+
+    class Query(graphene.ObjectType):
+        reporter = graphene.Field(ReporterType)
+
+        def resolve_reporter(self, info):
+            return SimpleLazyObject(lambda: SimpleLazyObject(lambda: Reporter(id=1)))
+
+    schema = graphene.Schema(query=Query)
+    query = """
+        query {
+          reporter {
+            id
+          }
+        }
+    """
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data == {"reporter": {"id": "1"}}
+
+
 def test_should_query_well():
     class ReporterType(DjangoObjectType):
         class Meta:

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -270,7 +270,7 @@ class DjangoObjectType(ObjectType):
     def is_type_of(cls, root, info):
         if isinstance(root, cls):
             return True
-        if not is_valid_django_model(type(root.__class__)):
+        if not is_valid_django_model(root.__class__):
             raise Exception(('Received incompatible instance "{}".').format(root))
 
         if cls._meta.model._meta.proxy:

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -268,12 +268,9 @@ class DjangoObjectType(ObjectType):
 
     @classmethod
     def is_type_of(cls, root, info):
-        if isinstance(root, SimpleLazyObject):
-            root._setup()
-            root = root._wrapped
         if isinstance(root, cls):
             return True
-        if not is_valid_django_model(type(root)):
+        if not is_valid_django_model(type(root.__class__)):
             raise Exception(('Received incompatible instance "{}".').format(root))
 
         if cls._meta.model._meta.proxy:


### PR DESCRIPTION
This API is not meant to be used, and it breaks when double-wrapped lazy objects occur, which appears to be a long standing practice.

See original issue in django-otp https://github.com/django-otp/django-otp/pull/36

This was introduced a long time ago, in v1.1.0, surprised it hasn't come up before?
https://github.com/graphql-python/graphene-django/commit/d73f4aa23581d7604cd92a80e8890ad490170094

At any rate, if you have both `AuthenticationMiddleware` and Django OTP, this will blow up with:

```
Exception: Received incompatible instance
```