### PR TITLE
GraphQlView: Do not 'instantiate_middleware' if middleware is already a MiddlewareManager

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -15,6 +15,7 @@ from graphql.error import format_error as format_graphql_error
 from graphql.error import GraphQLError
 from graphql.execution import ExecutionResult
 from graphql.type.schema import GraphQLSchema
+from graphql.execution.middleware import MiddlewareManager
 
 from .settings import graphene_settings
 
@@ -86,7 +87,10 @@ class GraphQLView(View):
 
         self.schema = self.schema or schema
         if middleware is not None:
-            self.middleware = list(instantiate_middleware(middleware))
+            if isinstance(middleware, MiddlewareManager):
+                self.middleware = middleware
+            else:
+                self.middleware = list(instantiate_middleware(middleware))
         self.executor = executor
         self.root_value = root_value
         self.pretty = self.pretty or pretty


### PR DESCRIPTION
In graphq-core 2, the `MiddlewareManager` can have a `wrap_in_promise` boolean passed to activate/deactivate wrapping the middleware's result into a promise. This has a big performance impact on large requests.
https://github.com/graphql-python/graphql-core-legacy/blob/52e030bbc6001fd378515600f81ccea0e360131b/graphql/execution/middleware.py#L25

The executor is instantiating the middleware as a `MiddlewareManager` if it's anything else than already a `MiddlewareManager`:
https://github.com/graphql-python/graphql-core-legacy/blob/52e030bbc6001fd378515600f81ccea0e360131b/graphql/execution/executor.py#L102

So in `graphene_django/views.py` by always converting middleware into a list, it breaks the ability to passe the argument to the `MiddlewareManager` and always default to `wrap_in_promise=True`.

This PR simply checks if the middleware is already a `MiddlewareManager` and pass it without pre-processing, allowing the end-user to define it themselves.
