### PR TITLE
Use psycopg2-binary in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ setenv =
     DJANGO_SETTINGS_MODULE=django_test_settings
 deps =
     -e.[test]
-    psycopg2
+    psycopg2-binary
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2


### PR DESCRIPTION
I tried to use a Dockerfile to run all tox scenarios on my local and the first issue was it needed some extra packages to compile `psycopg2`. This change may not have any important affect on the current workflow but i see no reason to not change it.