### PR TITLE
DjangoConnectionField slice: use max_limit first, if set

### DIFF
--- a/graphene_django/debug/tests/test_query.py
+++ b/graphene_django/debug/tests/test_query.py
@@ -44,7 +44,9 @@ def test_should_query_field():
     """
     expected = {
         "reporter": {"lastName": "ABA"},
-        "__debug": {"sql": [{"rawSql": str(Reporter.objects.order_by("pk")[:1].query)}]},
+        "__debug": {
+            "sql": [{"rawSql": str(Reporter.objects.order_by("pk")[:1].query)}]
+        },
     }
     schema = graphene.Schema(query=Query)
     result = schema.execute(
@@ -116,17 +118,17 @@ def test_should_query_nested_field(graphene_settings, max_limit, does_count):
     query = str(Reporter.objects.order_by("pk")[:1].query)
     assert result.data["__debug"]["sql"][0]["rawSql"] == query
     if does_count:
-      assert "COUNT" in result.data["__debug"]["sql"][1]["rawSql"]
-      assert "tests_reporter_pets" in result.data["__debug"]["sql"][2]["rawSql"]
-      assert "COUNT" in result.data["__debug"]["sql"][3]["rawSql"]
-      assert "tests_reporter_pets" in result.data["__debug"]["sql"][4]["rawSql"]
-      assert len(result.data["__debug"]["sql"]) == 5
+        assert "COUNT" in result.data["__debug"]["sql"][1]["rawSql"]
+        assert "tests_reporter_pets" in result.data["__debug"]["sql"][2]["rawSql"]
+        assert "COUNT" in result.data["__debug"]["sql"][3]["rawSql"]
+        assert "tests_reporter_pets" in result.data["__debug"]["sql"][4]["rawSql"]
+        assert len(result.data["__debug"]["sql"]) == 5
     else:
-      assert len(result.data["__debug"]["sql"]) == 3
-      for i in range(len(result.data["__debug"]["sql"])):
-        assert "COUNT" not in result.data["__debug"]["sql"][i]["rawSql"]
-      assert "tests_reporter_pets" in result.data["__debug"]["sql"][1]["rawSql"]
-      assert "tests_reporter_pets" in result.data["__debug"]["sql"][2]["rawSql"]
+        assert len(result.data["__debug"]["sql"]) == 3
+        for i in range(len(result.data["__debug"]["sql"])):
+            assert "COUNT" not in result.data["__debug"]["sql"][i]["rawSql"]
+        assert "tests_reporter_pets" in result.data["__debug"]["sql"][1]["rawSql"]
+        assert "tests_reporter_pets" in result.data["__debug"]["sql"][2]["rawSql"]
 
     assert result.data["reporter"] == expected["reporter"]
 
@@ -218,15 +220,15 @@ def test_should_query_connection(graphene_settings, max_limit, does_count):
     assert not result.errors
     assert result.data["allReporters"] == expected["allReporters"]
     if does_count:
-      assert len(result.data["__debug"]["sql"]) == 2
-      assert "COUNT" in result.data["__debug"]["sql"][0]["rawSql"]
-      query = str(Reporter.objects.all()[:1].query)
-      assert result.data["__debug"]["sql"][1]["rawSql"] == query
+        assert len(result.data["__debug"]["sql"]) == 2
+        assert "COUNT" in result.data["__debug"]["sql"][0]["rawSql"]
+        query = str(Reporter.objects.all()[:1].query)
+        assert result.data["__debug"]["sql"][1]["rawSql"] == query
     else:
-      assert len(result.data["__debug"]["sql"]) == 1
-      assert "COUNT" not in result.data["__debug"]["sql"][0]["rawSql"]
-      query = str(Reporter.objects.all()[:1].query)
-      assert result.data["__debug"]["sql"][0]["rawSql"] == query
+        assert len(result.data["__debug"]["sql"]) == 1
+        assert "COUNT" not in result.data["__debug"]["sql"][0]["rawSql"]
+        query = str(Reporter.objects.all()[:1].query)
+        assert result.data["__debug"]["sql"][0]["rawSql"] == query
 
 
 @pytest.mark.parametrize("max_limit,does_count", [(None, True), (100, False)])
@@ -277,12 +279,12 @@ def test_should_query_connectionfilter(graphene_settings, max_limit, does_count)
     assert not result.errors
     assert result.data["allReporters"] == expected["allReporters"]
     if does_count:
-      assert len(result.data["__debug"]["sql"]) == 2
-      assert "COUNT" in result.data["__debug"]["sql"][0]["rawSql"]
-      query = str(Reporter.objects.all()[:1].query)
-      assert result.data["__debug"]["sql"][1]["rawSql"] == query
+        assert len(result.data["__debug"]["sql"]) == 2
+        assert "COUNT" in result.data["__debug"]["sql"][0]["rawSql"]
+        query = str(Reporter.objects.all()[:1].query)
+        assert result.data["__debug"]["sql"][1]["rawSql"] == query
     else:
-      assert len(result.data["__debug"]["sql"]) == 1
-      assert "COUNT" not in result.data["__debug"]["sql"][0]["rawSql"]
-      query = str(Reporter.objects.all()[:1].query)
-      assert result.data["__debug"]["sql"][0]["rawSql"] == query
+        assert len(result.data["__debug"]["sql"]) == 1
+        assert "COUNT" not in result.data["__debug"]["sql"][0]["rawSql"]
+        query = str(Reporter.objects.all()[:1].query)
+        assert result.data["__debug"]["sql"][0]["rawSql"] == query

--- a/graphene_django/debug/tests/test_query.py
+++ b/graphene_django/debug/tests/test_query.py
@@ -1,4 +1,5 @@
 import graphene
+import pytest
 from graphene.relay import Node
 from graphene_django import DjangoConnectionField, DjangoObjectType
 
@@ -24,7 +25,7 @@ def test_should_query_field():
 
     class Query(graphene.ObjectType):
         reporter = graphene.Field(ReporterType)
-        debug = graphene.Field(DjangoDebug, name="_debug")
+        debug = graphene.Field(DjangoDebug, name="__debug")
 
         def resolve_reporter(self, info, **args):
             return Reporter.objects.first()
@@ -34,7 +35,7 @@ def test_should_query_field():
           reporter {
             lastName
           }
-          _debug {
+          __debug {
             sql {
               rawSql
             }
@@ -43,7 +44,7 @@ def test_should_query_field():
     """
     expected = {
         "reporter": {"lastName": "ABA"},
-        "_debug": {"sql": [{"rawSql": str(Reporter.objects.order_by("pk")[:1].query)}]},
+        "__debug": {"sql": [{"rawSql": str(Reporter.objects.order_by("pk")[:1].query)}]},
     }
     schema = graphene.Schema(query=Query)
     result = schema.execute(
@@ -53,7 +54,10 @@ def test_should_query_field():
     assert result.data == expected
 
 
-def test_should_query_nested_field():
+@pytest.mark.parametrize("max_limit,does_count", [(None, True), (100, False)])
+def test_should_query_nested_field(graphene_settings, max_limit, does_count):
+    graphene_settings.RELAY_CONNECTION_MAX_LIMIT = max_limit
+
     r1 = Reporter(last_name="ABA")
     r1.save()
     r2 = Reporter(last_name="Griffin")
@@ -111,11 +115,18 @@ def test_should_query_nested_field():
     assert not result.errors
     query = str(Reporter.objects.order_by("pk")[:1].query)
     assert result.data["__debug"]["sql"][0]["rawSql"] == query
-    assert "COUNT" in result.data["__debug"]["sql"][1]["rawSql"]
-    assert "tests_reporter_pets" in result.data["__debug"]["sql"][2]["rawSql"]
-    assert "COUNT" in result.data["__debug"]["sql"][3]["rawSql"]
-    assert "tests_reporter_pets" in result.data["__debug"]["sql"][4]["rawSql"]
-    assert len(result.data["__debug"]["sql"]) == 5
+    if does_count:
+      assert "COUNT" in result.data["__debug"]["sql"][1]["rawSql"]
+      assert "tests_reporter_pets" in result.data["__debug"]["sql"][2]["rawSql"]
+      assert "COUNT" in result.data["__debug"]["sql"][3]["rawSql"]
+      assert "tests_reporter_pets" in result.data["__debug"]["sql"][4]["rawSql"]
+      assert len(result.data["__debug"]["sql"]) == 5
+    else:
+      assert len(result.data["__debug"]["sql"]) == 3
+      for i in range(len(result.data["__debug"]["sql"])):
+        assert "COUNT" not in result.data["__debug"]["sql"][i]["rawSql"]
+      assert "tests_reporter_pets" in result.data["__debug"]["sql"][1]["rawSql"]
+      assert "tests_reporter_pets" in result.data["__debug"]["sql"][2]["rawSql"]
 
     assert result.data["reporter"] == expected["reporter"]
 
@@ -133,7 +144,7 @@ def test_should_query_list():
 
     class Query(graphene.ObjectType):
         all_reporters = graphene.List(ReporterType)
-        debug = graphene.Field(DjangoDebug, name="_debug")
+        debug = graphene.Field(DjangoDebug, name="__debug")
 
         def resolve_all_reporters(self, info, **args):
             return Reporter.objects.all()
@@ -143,7 +154,7 @@ def test_should_query_list():
           allReporters {
             lastName
           }
-          _debug {
+          __debug {
             sql {
               rawSql
             }
@@ -152,7 +163,7 @@ def test_should_query_list():
     """
     expected = {
         "allReporters": [{"lastName": "ABA"}, {"lastName": "Griffin"}],
-        "_debug": {"sql": [{"rawSql": str(Reporter.objects.all().query)}]},
+        "__debug": {"sql": [{"rawSql": str(Reporter.objects.all().query)}]},
     }
     schema = graphene.Schema(query=Query)
     result = schema.execute(
@@ -162,7 +173,10 @@ def test_should_query_list():
     assert result.data == expected
 
 
-def test_should_query_connection():
+@pytest.mark.parametrize("max_limit,does_count", [(None, True), (100, False)])
+def test_should_query_connection(graphene_settings, max_limit, does_count):
+    graphene_settings.RELAY_CONNECTION_MAX_LIMIT = max_limit
+
     r1 = Reporter(last_name="ABA")
     r1.save()
     r2 = Reporter(last_name="Griffin")
@@ -175,7 +189,7 @@ def test_should_query_connection():
 
     class Query(graphene.ObjectType):
         all_reporters = DjangoConnectionField(ReporterType)
-        debug = graphene.Field(DjangoDebug, name="_debug")
+        debug = graphene.Field(DjangoDebug, name="__debug")
 
         def resolve_all_reporters(self, info, **args):
             return Reporter.objects.all()
@@ -189,7 +203,7 @@ def test_should_query_connection():
               }
             }
           }
-          _debug {
+          __debug {
             sql {
               rawSql
             }
@@ -203,12 +217,22 @@ def test_should_query_connection():
     )
     assert not result.errors
     assert result.data["allReporters"] == expected["allReporters"]
-    assert "COUNT" in result.data["_debug"]["sql"][0]["rawSql"]
-    query = str(Reporter.objects.all()[:1].query)
-    assert result.data["_debug"]["sql"][1]["rawSql"] == query
+    if does_count:
+      assert len(result.data["__debug"]["sql"]) == 2
+      assert "COUNT" in result.data["__debug"]["sql"][0]["rawSql"]
+      query = str(Reporter.objects.all()[:1].query)
+      assert result.data["__debug"]["sql"][1]["rawSql"] == query
+    else:
+      assert len(result.data["__debug"]["sql"]) == 1
+      assert "COUNT" not in result.data["__debug"]["sql"][0]["rawSql"]
+      query = str(Reporter.objects.all()[:1].query)
+      assert result.data["__debug"]["sql"][0]["rawSql"] == query
 
 
-def test_should_query_connectionfilter():
+@pytest.mark.parametrize("max_limit,does_count", [(None, True), (100, False)])
+def test_should_query_connectionfilter(graphene_settings, max_limit, does_count):
+    graphene_settings.RELAY_CONNECTION_MAX_LIMIT = max_limit
+
     from ...filter import DjangoFilterConnectionField
 
     r1 = Reporter(last_name="ABA")
@@ -224,7 +248,7 @@ def test_should_query_connectionfilter():
     class Query(graphene.ObjectType):
         all_reporters = DjangoFilterConnectionField(ReporterType, fields=["last_name"])
         s = graphene.String(resolver=lambda *_: "S")
-        debug = graphene.Field(DjangoDebug, name="_debug")
+        debug = graphene.Field(DjangoDebug, name="__debug")
 
         def resolve_all_reporters(self, info, **args):
             return Reporter.objects.all()
@@ -238,7 +262,7 @@ def test_should_query_connectionfilter():
               }
             }
           }
-          _debug {
+          __debug {
             sql {
               rawSql
             }
@@ -252,6 +276,13 @@ def test_should_query_connectionfilter():
     )
     assert not result.errors
     assert result.data["allReporters"] == expected["allReporters"]
-    assert "COUNT" in result.data["_debug"]["sql"][0]["rawSql"]
-    query = str(Reporter.objects.all()[:1].query)
-    assert result.data["_debug"]["sql"][1]["rawSql"] == query
+    if does_count:
+      assert len(result.data["__debug"]["sql"]) == 2
+      assert "COUNT" in result.data["__debug"]["sql"][0]["rawSql"]
+      query = str(Reporter.objects.all()[:1].query)
+      assert result.data["__debug"]["sql"][1]["rawSql"] == query
+    else:
+      assert len(result.data["__debug"]["sql"]) == 1
+      assert "COUNT" not in result.data["__debug"]["sql"][0]["rawSql"]
+      query = str(Reporter.objects.all()[:1].query)
+      assert result.data["__debug"]["sql"][0]["rawSql"] == query

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -127,12 +127,12 @@ class DjangoConnectionField(ConnectionField):
         return connection._meta.node.get_queryset(queryset, info)
 
     @classmethod
-    def resolve_connection(cls, connection, args, iterable):
+    def resolve_connection(cls, connection, args, iterable, max_limit=None):
         iterable = maybe_queryset(iterable)
         if isinstance(iterable, QuerySet):
-            _len = iterable.count()
+            _len = max_limit or iterable.count()
         else:
-            _len = len(iterable)
+            _len = max_limit or len(iterable)
         connection = connection_from_list_slice(
             iterable,
             args,
@@ -189,7 +189,7 @@ class DjangoConnectionField(ConnectionField):
         # thus the iterable gets refiltered by resolve_queryset
         # but iterable might be promise
         iterable = queryset_resolver(connection, iterable, info, args)
-        on_resolve = partial(cls.resolve_connection, connection, args)
+        on_resolve = partial(cls.resolve_connection, connection, args, max_limit=max_limit)
 
         if Promise.is_thenable(iterable):
             return Promise.resolve(iterable).then(on_resolve)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -129,6 +129,9 @@ class DjangoConnectionField(ConnectionField):
     @classmethod
     def resolve_connection(cls, connection, args, iterable, max_limit=None):
         iterable = maybe_queryset(iterable)
+        # When slicing from the end, need to retrieve the iterable length.
+        if args.get("last"):
+            max_limit = None
         if isinstance(iterable, QuerySet):
             _len = max_limit or iterable.count()
         else:
@@ -189,7 +192,9 @@ class DjangoConnectionField(ConnectionField):
         # thus the iterable gets refiltered by resolve_queryset
         # but iterable might be promise
         iterable = queryset_resolver(connection, iterable, info, args)
-        on_resolve = partial(cls.resolve_connection, connection, args, max_limit=max_limit)
+        on_resolve = partial(
+            cls.resolve_connection, connection, args, max_limit=max_limit
+        )
 
         if Promise.is_thenable(iterable):
             return Promise.resolve(iterable).then(on_resolve)

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -1086,9 +1086,9 @@ def test_should_resolve_get_queryset_connectionfields():
 
 REPORTERS = [
     dict(
-        first_name=f"First {i}",
-        last_name=f"Last {i}",
-        email=f"johndoe+{i}@example.com",
+        first_name="First {}".format(i),
+        last_name=f"Last {}".format(i),
+        email="johndoe+{i}@example.com".format(i),
         a_choice=1,
     )
     for i in range(6)

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -1088,7 +1088,7 @@ REPORTERS = [
     dict(
         first_name="First {}".format(i),
         last_name="Last {}".format(i),
-        email="johndoe+{i}@example.com".format(i),
+        email="johndoe+{}@example.com".format(i),
         a_choice=1,
     )
     for i in range(6)

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -1084,6 +1084,48 @@ def test_should_resolve_get_queryset_connectionfields():
     assert result.data == expected
 
 
+REPORTERS = [
+    dict(
+        first_name=f"First {i}",
+        last_name=f"Last {i}",
+        email=f"johndoe+{i}@example.com",
+        a_choice=1,
+    )
+    for i in range(6)
+]
+
+
+def test_should_return_max_limit(graphene_settings):
+    graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 4
+    reporters = [Reporter(**kwargs) for kwargs in REPORTERS]
+    Reporter.objects.bulk_create(reporters)
+
+    class ReporterType(DjangoObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node,)
+
+    class Query(graphene.ObjectType):
+        all_reporters = DjangoConnectionField(ReporterType)
+
+    schema = graphene.Schema(query=Query)
+    query = """
+        query AllReporters {
+            allReporters {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
+        }
+    """
+
+    result = schema.execute(query)
+    assert not result.errors
+    assert len(result.data["allReporters"]["edges"]) == 4
+
+
 def test_should_preserve_prefetch_related(django_assert_num_queries):
     class ReporterType(DjangoObjectType):
         class Meta:

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -1130,7 +1130,7 @@ def test_should_preserve_prefetch_related(django_assert_num_queries):
         }
     """
     schema = graphene.Schema(query=Query)
-    with django_assert_num_queries(3) as captured:
+    with django_assert_num_queries(2) as captured:
         result = schema.execute(query)
     assert not result.errors
 

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -1087,7 +1087,7 @@ def test_should_resolve_get_queryset_connectionfields():
 REPORTERS = [
     dict(
         first_name="First {}".format(i),
-        last_name=f"Last {}".format(i),
+        last_name="Last {}".format(i),
         email="johndoe+{i}@example.com".format(i),
         a_choice=1,
     )


### PR DESCRIPTION
I found an interesting performance issue, where if I query without `first` or `last`, and there is a setting for `RELAY_CONNECTION_MAX_LIMIT`, the resolver attempts to pull in the entire queryset.

This is way overkill when there are thousands of items, so it seems wise to use `max_limit` when available.

I opted for optional kwarg in `resolve_connection` to maintain backwards compatibility if anyone overwrote this method, but it would be cleaner to require it, since the calling method `connection_resolver` always has it.

On a query that has multiple nested `DjangoConnectionField`s, I imagine this would reduce queries and data over the SQL wire by a lot.