### PR TITLE
Error in signature of callproc() and execute()

### DIFF
--- a/graphene_django/debug/sql/tracking.py
+++ b/graphene_django/debug/sql/tracking.py
@@ -148,10 +148,10 @@ class NormalCursorWrapper(object):
             # We keep `sql` to maintain backwards compatibility
             self.logger.object.sql.append(_sql)
 
-    def callproc(self, procname, params=()):
+    def callproc(self, procname, params=None):
         return self._record(self.cursor.callproc, procname, params)
 
-    def execute(self, sql, params=()):
+    def execute(self, sql, params=None):
         return self._record(self.cursor.execute, sql, params)
 
     def executemany(self, sql, param_list):


### PR DESCRIPTION
Fixes #586

The default params `()` in the two `NormalCursorWrapper` methods should be `None` to match what django expects in the code block below. A bare `cursor.execute(sql)` will have `params=()` added to it by the Wrapper which fails to match the `if` in the code block below, causing the IndexError. 

```
    def execute(self, sql, params=None):
        self.db.validate_no_broken_transaction()
        with self.db.wrap_database_errors:
            if params is None:
                return self.cursor.execute(sql)
            else:
>               return self.cursor.execute(sql, params)
E               IndexError: tuple index out of range

django/db/backends/utils.py:65: IndexError
```

This fix was done @kevingill1966 in their fork, I'm just making a PR to have it added =)