### PR TITLE
Start raising DeprecationWarnings for using only_fields and exclude_fields (v3)

### DIFF
--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -290,7 +290,7 @@ def with_local_registry(func):
 
 @with_local_registry
 def test_django_objecttype_only_fields():
-    with pytest.warns(PendingDeprecationWarning):
+    with pytest.warns(DeprecationWarning):
 
         class Reporter(DjangoObjectType):
             class Meta:
@@ -347,7 +347,7 @@ def test_django_objecttype_all_fields():
 
 @with_local_registry
 def test_django_objecttype_exclude_fields():
-    with pytest.warns(PendingDeprecationWarning):
+    with pytest.warns(DeprecationWarning):
 
         class Reporter(DjangoObjectType):
             class Meta:

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -194,7 +194,7 @@ class DjangoObjectType(ObjectType):
         if only_fields:
             warnings.warn(
                 "Defining `only_fields` is deprecated in favour of `fields`.",
-                PendingDeprecationWarning,
+                DeprecationWarning,
                 stacklevel=2,
             )
             fields = only_fields
@@ -210,7 +210,7 @@ class DjangoObjectType(ObjectType):
         if exclude_fields:
             warnings.warn(
                 "Defining `exclude_fields` is deprecated in favour of `exclude`.",
-                PendingDeprecationWarning,
+                DeprecationWarning,
                 stacklevel=2,
             )
             exclude = exclude_fields


### PR DESCRIPTION
As discussed in #691 and planned in #705 this PR starts raising `DeprecationWarnings` for using `only_fields` and `exclude_fields` in v3. Before `PendingDepcrecationWarnings` were raised.