### PR TITLE
Make v3 django choice field enum naming default

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -142,20 +142,20 @@ Default: ``False``
    # ]
 
 
-``DJANGO_CHOICE_FIELD_ENUM_V3_NAMING``
+``DJANGO_CHOICE_FIELD_ENUM_V2_NAMING``
 --------------------------------------
 
-Set to ``True`` to use the new naming format for the auto generated Enum types from Django choice fields. The new format looks like this: ``{app_label}{object_name}{field_name}Choices``
+Set to ``True`` to use the old naming format for the auto generated Enum types from Django choice fields. The old format looks like this: ``{object_name}_{field_name}``
 
 Default: ``False``
 
 
 ``DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME``
---------------------------------------
+----------------------------------------
 
 Define the path of a function that takes the Django choice field and returns a string to completely customise the naming for the Enum type.
 
-If set to a function then the ``DJANGO_CHOICE_FIELD_ENUM_V3_NAMING`` setting is ignored.
+If set to a function then the ``DJANGO_CHOICE_FIELD_ENUM_V2_NAMING`` setting is ignored.
 
 Default: ``None``
 

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -79,14 +79,14 @@ def generate_enum_name(django_model_meta, field):
             graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME
         )
         name = custom_func(field)
-    elif graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING is True:
+    elif graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V2_NAMING is True:
+        name = to_camel_case("{}_{}".format(django_model_meta.object_name, field.name))
+    else:
         name = "{app_label}{object_name}{field_name}Choices".format(
             app_label=to_camel_case(django_model_meta.app_label.title()),
             object_name=django_model_meta.object_name,
             field_name=to_camel_case(field.name.title()),
         )
-    else:
-        name = to_camel_case("{}_{}".format(django_model_meta.object_name, field.name))
     return name
 
 

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -35,8 +35,8 @@ DEFAULTS = {
     # Max items returned in ConnectionFields / FilterConnectionFields
     "RELAY_CONNECTION_MAX_LIMIT": 100,
     "CAMELCASE_ERRORS": True,
-    # Set to True to enable v3 naming convention for choice field Enum's
-    "DJANGO_CHOICE_FIELD_ENUM_V3_NAMING": False,
+    # Set to True to enable v2 naming convention for choice field Enum's
+    "DJANGO_CHOICE_FIELD_ENUM_V2_NAMING": False,
     "DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME": None,
 }
 

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -159,7 +159,7 @@ def test_field_with_choices_convert_enum():
 
     graphene_type = convert_django_field_with_choices(field)
     assert isinstance(graphene_type, graphene.Enum)
-    assert graphene_type._meta.name == "TranslatedModelLanguage"
+    assert graphene_type._meta.name == "TestTranslatedModelLanguageChoices"
     assert graphene_type._meta.enum.__members__["ES"].value == "es"
     assert graphene_type._meta.enum.__members__["ES"].description == "Spanish"
     assert graphene_type._meta.enum.__members__["EN"].value == "en"
@@ -344,9 +344,8 @@ def test_should_postgres_range_convert_list():
     assert field.type.of_type.of_type == graphene.Int
 
 
-def test_generate_enum_name(graphene_settings):
+def test_generate_enum_name():
     MockDjangoModelMeta = namedtuple("DjangoMeta", ["app_label", "object_name"])
-    graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = True
 
     # Simple case
     field = graphene.Field(graphene.String, name="type")
@@ -362,3 +361,20 @@ def test_generate_enum_name(graphene_settings):
         generate_enum_name(model_meta, field)
         == "SomeLongAppNameSomeObjectFizzBuzzChoices"
     )
+
+
+def test_generate_v2_enum_name(graphene_settings):
+    MockDjangoModelMeta = namedtuple("DjangoMeta", ["app_label", "object_name"])
+    graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V2_NAMING = True
+
+    # Simple case
+    field = graphene.Field(graphene.String, name="type")
+    model_meta = MockDjangoModelMeta(app_label="users", object_name="User")
+    assert generate_enum_name(model_meta, field) == "UserType"
+
+    # More complicated multiple work case
+    field = graphene.Field(graphene.String, name="fizz_buzz")
+    model_meta = MockDjangoModelMeta(
+        app_label="some_long_app_name", object_name="SomeObject"
+    )
+    assert generate_enum_name(model_meta, field) == "SomeObjectFizzBuzz"

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -138,10 +138,10 @@ def test_schema_representation():
           editor: Reporter!
 
           \"""Language\"""
-          lang: ArticleLang!
+          lang: TestsArticleLangChoices!
 
           \"""\"""
-          importance: ArticleImportance
+          importance: TestsArticleImportanceChoices
         }
 
         \"""An object with an ID\"""
@@ -165,7 +165,7 @@ def test_schema_representation():
         scalar DateTime
 
         \"""An enumeration.\"""
-        enum ArticleLang {
+        enum TestsArticleLangChoices {
           \"""Spanish\"""
           ES
 
@@ -174,7 +174,7 @@ def test_schema_representation():
         }
 
         \"""An enumeration.\"""
-        enum ArticleImportance {
+        enum TestsArticleImportanceChoices {
           \"""Very important\"""
           A_1
 
@@ -200,17 +200,17 @@ def test_schema_representation():
           pets: [Reporter!]!
 
           \"""\"""
-          aChoice: ReporterAChoice
+          aChoice: TestsReporterAChoiceChoices
 
           \"""\"""
-          reporterType: ReporterReporterType
+          reporterType: TestsReporterReporterTypeChoices
 
           \"""\"""
           articles(before: String = null, after: String = null, first: Int = null, last: Int = null): ArticleConnection!
         }
 
         \"""An enumeration.\"""
-        enum ReporterAChoice {
+        enum TestsReporterAChoiceChoices {
           \"""this\"""
           A_1
 
@@ -219,7 +219,7 @@ def test_schema_representation():
         }
 
         \"""An enumeration.\"""
-        enum ReporterReporterType {
+        enum TestsReporterReporterTypeChoices {
           \"""Regular\"""
           A_1
 
@@ -547,14 +547,14 @@ class TestDjangoObjectType:
               id: ID!
 
               \"""\"""
-              kind: PetModelKind!
+              kind: TestsPetModelKindChoices!
 
               \"""\"""
               cuteness: Int!
             }
 
             \"""An enumeration.\"""
-            enum PetModelKind {
+            enum TestsPetModelKindChoices {
               \"""Cat\"""
               CAT
 
@@ -597,8 +597,6 @@ class TestDjangoObjectType:
     def test_django_objecttype_convert_choices_enum_naming_collisions(
         self, PetModel, graphene_settings
     ):
-        graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V3_NAMING = True
-
         class PetModelKind(DjangoObjectType):
             class Meta:
                 model = PetModel


### PR DESCRIPTION
As discussed in #860 and planned in #705 this PR makes the v3 django choice field enum naming default. It also replaces the `DJANGO_CHOICE_FIELD_ENUM_V3_NAMING` with a `DJANGO_CHOICE_FIELD_ENUM_V2_NAMING` setting to re-enable the old naming convention.