### PR TITLE
Move to_const function from Graphene into Graphene-Django

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -20,13 +20,14 @@ from graphene import (
     Time,
 )
 from graphene.types.json import JSONString
-from graphene.utils.str_converters import to_camel_case, to_const
+from graphene.utils.str_converters import to_camel_case
 from graphql import assert_valid_name
 
 from .settings import graphene_settings
 from .compat import ArrayField, HStoreField, JSONField, RangeField
 from .fields import DjangoListField, DjangoConnectionField
 from .utils import import_single_dispatch
+from .utils.str_converters import to_const
 
 singledispatch = import_single_dispatch()
 

--- a/graphene_django/utils/str_converters.py
+++ b/graphene_django/utils/str_converters.py
@@ -1,0 +1,6 @@
+import re
+from unidecode import unidecode
+
+
+def to_const(string):
+    return re.sub(r"[\W|^]+", "_", unidecode(string)).upper()

--- a/graphene_django/utils/tests/test_str_converters.py
+++ b/graphene_django/utils/tests/test_str_converters.py
@@ -1,0 +1,10 @@
+# coding: utf-8
+from ..str_converters import to_const
+
+
+def test_to_const():
+    assert to_const('snakes $1. on a "#plane') == "SNAKES_1_ON_A_PLANE"
+
+
+def test_to_const_unicode():
+    assert to_const("Skoða þetta unicode stöff") == "SKODA_THETTA_UNICODE_STOFF"

--- a/graphene_django/utils/tests/test_str_converters.py
+++ b/graphene_django/utils/tests/test_str_converters.py
@@ -7,4 +7,4 @@ def test_to_const():
 
 
 def test_to_const_unicode():
-    assert to_const("Skoða þetta unicode stöff") == "SKODA_THETTA_UNICODE_STOFF"
+    assert to_const(u"Skoða þetta unicode stöff") == "SKODA_THETTA_UNICODE_STOFF"

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "Django>=1.11",
         "singledispatch>=3.4.0.3",
         "promise>=2.1",
+        "unidecode>=1.1.1,<2",
     ],
     setup_requires=["pytest-runner"],
     tests_require=tests_require,


### PR DESCRIPTION
This PR moves the `to_const` string converter function from the Graphene project into the Graphene-Django one because it is only used in the Graphene-Django project. See: https://github.com/graphql-python/graphene/issues/1208