### PR TITLE
Do not break when after is greater than list_length

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -144,7 +144,10 @@ class DjangoConnectionField(ConnectionField):
                 min(max_limit, list_length) if max_limit is not None else list_length
             )
 
-        after = get_offset_with_default(args.get("after"), -1) + 1
+        # If after is higher than list_length, connection_from_list_slice
+        # would try to do a negative slicing which makes django throw an
+        # AssertionError
+        after = min(get_offset_with_default(args.get("after"), -1) + 1, list_length)
 
         if max_limit is not None and "first" not in args:
             args["first"] = max_limit


### PR DESCRIPTION
I added a test that, without the change do `graphene_django/fields.py` breaks with the traceback described in the issue bellow.

Fix https://github.com/graphql-python/graphene-django/issues/998