### PR TITLE
Update GraphiQL, add GraphiQL subscription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,42 @@ urlpatterns = [
 ]
 ```
 
+### Subscription Support
+
+The `graphene-django` project does not currently support GraphQL subscriptions out of the box. However, there are
+several community-driven modules for adding subscription support, and the GraphiQL interface provided by
+`graphene-django` supports subscriptions over websockets.
+
+To implement websocket-based support for GraphQL subscriptions, you'll need to:
+
+1. Install and configure [`django-channels`](https://channels.readthedocs.io/en/latest/installation.html).
+2. Install and configure<sup>1, 2</sup> a third-party module for adding subscription support over websockets. A few
+   options include:
+   - [`graphql-python/graphql-ws`](https://github.com/graphql-python/graphql-ws)
+   - [`datavance/django-channels-graphql-ws`](https://github.com/datadvance/DjangoChannelsGraphqlWs)
+   - [`jaydenwindle/graphene-subscriptions`](https://github.com/jaydenwindle/graphene-subscriptions)
+3. Ensure that your application (or at least your GraphQL endpoint) is being served via an ASGI protocol server like
+   `daphne` (built in to `django-channels`), [`uvicorn`](https://www.uvicorn.org/), or
+   [`hypercorn`](https://pgjones.gitlab.io/hypercorn/).
+
+> **<sup>1</sup> Note:** By default, the GraphiQL interface that comes with `graphene-django` assumes that you are
+> handling subscriptions at the same path as any other operation (i.e., you configured both `urls.py` and `routing.py`
+> to handle GraphQL operations at the same path, like `/graphql`).
+>
+> If these URLs differ, GraphiQL will try to run your subscription over HTTP, which will produce an error. If you need
+> to use a different URL for handling websocket connections, you can configure `SUBSCRIPTION_PATH` in your
+> `settings.py`:
+>
+> ```python
+> GRAPHENE = {
+>     # ...
+>     "SUBSCRIPTION_PATH": "/ws/graphql"  # The path you configured in `routing.py`, including a leading slash.
+> }
+> ```
+
+Once your application is properly configured to handle subscriptions, you can use the GraphiQL interface to test
+subscriptions like any other operation.
+
 ## Examples
 
 Here is a simple Django model:

--- a/README.md
+++ b/README.md
@@ -59,42 +59,6 @@ urlpatterns = [
 ]
 ```
 
-### Subscription Support
-
-The `graphene-django` project does not currently support GraphQL subscriptions out of the box. However, there are
-several community-driven modules for adding subscription support, and the GraphiQL interface provided by
-`graphene-django` supports subscriptions over websockets.
-
-To implement websocket-based support for GraphQL subscriptions, you'll need to:
-
-1. Install and configure [`django-channels`](https://channels.readthedocs.io/en/latest/installation.html).
-2. Install and configure<sup>1, 2</sup> a third-party module for adding subscription support over websockets. A few
-   options include:
-   - [`graphql-python/graphql-ws`](https://github.com/graphql-python/graphql-ws)
-   - [`datavance/django-channels-graphql-ws`](https://github.com/datadvance/DjangoChannelsGraphqlWs)
-   - [`jaydenwindle/graphene-subscriptions`](https://github.com/jaydenwindle/graphene-subscriptions)
-3. Ensure that your application (or at least your GraphQL endpoint) is being served via an ASGI protocol server like
-   `daphne` (built in to `django-channels`), [`uvicorn`](https://www.uvicorn.org/), or
-   [`hypercorn`](https://pgjones.gitlab.io/hypercorn/).
-
-> **<sup>1</sup> Note:** By default, the GraphiQL interface that comes with `graphene-django` assumes that you are
-> handling subscriptions at the same path as any other operation (i.e., you configured both `urls.py` and `routing.py`
-> to handle GraphQL operations at the same path, like `/graphql`).
->
-> If these URLs differ, GraphiQL will try to run your subscription over HTTP, which will produce an error. If you need
-> to use a different URL for handling websocket connections, you can configure `SUBSCRIPTION_PATH` in your
-> `settings.py`:
->
-> ```python
-> GRAPHENE = {
->     # ...
->     "SUBSCRIPTION_PATH": "/ws/graphql"  # The path you configured in `routing.py`, including a leading slash.
-> }
-> ```
-
-Once your application is properly configured to handle subscriptions, you can use the GraphiQL interface to test
-subscriptions like any other operation.
-
 ## Examples
 
 Here is a simple Django model:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ For more advanced use, check out the Relay tutorial.
    fields
    extra-types
    mutations
+   subscriptions
    filtering
    authorization
    debug

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -104,7 +104,7 @@ Default: ``100``
 
 
 ``CAMELCASE_ERRORS``
-------------------------------------
+--------------------
 
 When set to ``True`` field names in the ``errors`` object will be camel case.
 By default they will be snake case.
@@ -151,7 +151,7 @@ Default: ``False``
 
 
 ``DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME``
---------------------------------------
+----------------------------------------
 
 Define the path of a function that takes the Django choice field and returns a string to completely customise the naming for the Enum type.
 
@@ -173,7 +173,7 @@ Default: ``None``
 
 
 ``SUBSCRIPTION_PATH``
---------------------------------------
+---------------------
 
 Define an alternative URL path where subscription operations should be routed.
 
@@ -182,6 +182,7 @@ The GraphiQL interface will use this setting to intelligently route subscription
 Default: ``None``
 
 .. code:: python
+
    GRAPHENE = {
       'SUBSCRIPTION_PATH': "/ws/graphql"
    }

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -170,3 +170,18 @@ Default: ``None``
    GRAPHENE = {
       'DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME': "myapp.utils.enum_naming"
    }
+
+
+``SUBSCRIPTION_PATH``
+--------------------------------------
+
+Define an alternative URL path where subscription operations should be routed.
+
+The GraphiQL interface will use this setting to intelligently route subscription operations. This is useful if you have more advanced infrastructure requirements that prevent websockets from being handled at the same path (e.g., a WSGI server listening at ``/graphql`` and an ASGI server listening at ``/ws/graphql``).
+
+Default: ``None``
+
+.. code:: python
+   GRAPHENE = {
+      'SUBSCRIPTION_PATH': "/ws/graphql"
+   }

--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -1,0 +1,42 @@
+Subscription Support
+====================
+
+The ``graphene-django`` project does not currently support GraphQL subscriptions out of the box. However, there are
+several community-driven modules for adding subscription support, and the GraphiQL interface provided by
+``graphene-django`` supports subscriptions over websockets.
+
+To implement websocket-based support for GraphQL subscriptions, you’ll need to do the following:
+
+1. Install and configure `django-channels <https://channels.readthedocs.io/en/latest/installation.html>`_.
+2. Install and configure* a third-party module for adding subscription support over websockets. A few options include:
+
+   -  `graphql-python/graphql-ws <https://github.com/graphql-python/graphql-ws>`_
+   -  `datavance/django-channels-graphql-ws <https://github.com/datadvance/DjangoChannelsGraphqlWs>`_
+   -  `jaydenwindle/graphene-subscriptions <https://github.com/jaydenwindle/graphene-subscriptions>`_
+
+3. Ensure that your application (or at least your GraphQL endpoint) is being served via an ASGI protocol server like
+   daphne (built in to ``django-channels``), `uvicorn <https://www.uvicorn.org/>`_, or
+   `hypercorn <https://pgjones.gitlab.io/hypercorn/>`_.
+
+..
+
+   *** Note:** By default, the GraphiQL interface that comes with
+   ``graphene-django`` assumes that you are handling subscriptions at
+   the same path as any other operation (i.e., you configured both
+   ``urls.py`` and ``routing.py`` to handle GraphQL operations at the
+   same path, like ``/graphql``).
+
+   If these URLs differ, GraphiQL will try to run your subscription over
+   HTTP, which will produce an error. If you need to use a different URL
+   for handling websocket connections, you can configure
+   ``SUBSCRIPTION_PATH`` in your ``settings.py``:
+
+   .. code:: python
+
+      GRAPHENE = {
+          # ...
+          "SUBSCRIPTION_PATH": "/ws/graphql"  # The path you configured in `routing.py`, including a leading slash.
+      }
+
+Once your application is properly configured to handle subscriptions, you can use the GraphiQL interface to test
+subscriptions like any other operation.

--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -1,9 +1,9 @@
-Subscription Support
-====================
+Subscriptions
+=============
 
 The ``graphene-django`` project does not currently support GraphQL subscriptions out of the box. However, there are
-several community-driven modules for adding subscription support, and the GraphiQL interface provided by
-``graphene-django`` supports subscriptions over websockets.
+several community-driven modules for adding subscription support, and the provided GraphiQL interface supports
+running subscription operations over a websocket.
 
 To implement websocket-based support for GraphQL subscriptions, you’ll need to do the following:
 

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -39,6 +39,8 @@ DEFAULTS = {
     # Set to True to enable v3 naming convention for choice field Enum's
     "DJANGO_CHOICE_FIELD_ENUM_V3_NAMING": False,
     "DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME": None,
+    # Use a separate path for handling subscriptions.
+    "SUBSCRIPTION_PATH": None,
 }
 
 if settings.DEBUG:

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -29,10 +29,19 @@ add "&raw" to the end of the URL within a browser.
           crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/graphiql@{{graphiql_version}}/graphiql.min.js"
           crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/subscriptions-transport-ws@{{subscriptions_transport_ws_version}}/browser/client.js"
+          crossorigin="anonymous"></script>
 </head>
 <body>
   <div id="editor"></div>
   {% csrf_token %}
+  <script type="application/javascript">
+    window.GRAPHENE_SETTINGS = {
+    {% if subscription_path %}
+      subscriptionPath: "{{subscription_path}}",
+    {% endif %}
+    };
+  </script>
   <script src="{% static 'graphene_django/graphiql.js' %}"></script>
 </body>
 </html>

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -52,9 +52,10 @@ def instantiate_middleware(middlewares):
 
 
 class GraphQLView(View):
-    graphiql_version = "0.14.0"
+    graphiql_version = "1.0.3"
     graphiql_template = "graphene/graphiql.html"
-    react_version = "16.8.6"
+    react_version = "16.13.1"
+    subscriptions_transport_ws_version = "0.9.16"
 
     schema = None
     graphiql = False
@@ -64,6 +65,7 @@ class GraphQLView(View):
     root_value = None
     pretty = False
     batch = False
+    subscription_path = None
 
     def __init__(
         self,
@@ -75,6 +77,7 @@ class GraphQLView(View):
         pretty=False,
         batch=False,
         backend=None,
+        subscription_path=None,
     ):
         if not schema:
             schema = graphene_settings.SCHEMA
@@ -97,6 +100,8 @@ class GraphQLView(View):
         self.graphiql = self.graphiql or graphiql
         self.batch = self.batch or batch
         self.backend = backend
+        if subscription_path is None:
+            subscription_path = graphene_settings.SUBSCRIPTION_PATH
 
         assert isinstance(
             self.schema, GraphQLSchema
@@ -134,6 +139,8 @@ class GraphQLView(View):
                     request,
                     graphiql_version=self.graphiql_version,
                     react_version=self.react_version,
+                    subscriptions_transport_ws_version=self.subscriptions_transport_ws_version,
+                    subscription_path=self.subscription_path,
                 )
 
             if self.batch:


### PR DESCRIPTION
I recently spent some time implementing subscriptions at work, and ended up going down the rabbit hole of upgrading GraphiQL and adding subscription support to it.

This PR will:

* Update the GraphiQL template to use the latest versions of `react`, `react-dom`, `graphiql`, and (new) `subscriptions-transport-ws`.
* Add support for websocket connections and subscriptions to the GraphiQL template.
* Tweak the wrapping function in `graphiql.js` to inject global dependencies so that they're considered function-local by linters.
* Add a `SUBSCRIPTION_PATH` configuration option to allow GraphiQL to route subscriptions to a different path (allowing for more advanced infrastructure scenarios).
* Update the documentation to include some starting points for implementing subscriptions and configuring `SUBSCRIPTION_PATH`.
