### PR TITLE
Add headers support to GraphiQL

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -193,14 +193,14 @@ Default: ``None``
 
 GraphiQL starting from version 1.0.0 allows setting custom headers in similar fashion to query variables.
 
-Set to ``True`` to enable GraphiQL headers editor tab.
+Set to ``False`` if you want to disable GraphiQL headers editor tab for some reason.
 
 This setting is passed to ``headerEditorEnabled`` GraphiQL options, for details refer to GraphiQLDocs_.
 
 .. _GraphiQLDocs: https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
 
 
-Default: ``False``
+Default: ``True``
 
 .. code:: python
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -186,3 +186,24 @@ Default: ``None``
    GRAPHENE = {
       'SUBSCRIPTION_PATH': "/ws/graphql"
    }
+
+
+``GRAPHIQL_HEADER_EDITOR_ENABLED``
+---------------------
+
+GraphiQL starting from version 1.0.0 allows setting custom headers in similar fashion to query variables.
+
+Set to ``True`` to enable GraphiQL headers editor tab.
+
+This setting is passed to ``headerEditorEnabled`` GraphiQL options, for details refer to GraphiQLDocs_.
+
+.. _GraphiQLDocs: https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
+
+
+Default: ``False``
+
+.. code:: python
+
+   GRAPHENE = {
+      'GRAPHIQL_HEADER_EDITOR_ENABLED': True,
+   }

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -41,6 +41,10 @@ DEFAULTS = {
     "DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME": None,
     # Use a separate path for handling subscriptions.
     "SUBSCRIPTION_PATH": None,
+    # Set to True to enable GraphiQL headers editor tab
+    # This sets headerEditorEnabled GraphiQL option, for details go to
+    # https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
+    "GRAPHIQL_HEADER_EDITOR_ENABLED": False,
 }
 
 if settings.DEBUG:

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -41,10 +41,10 @@ DEFAULTS = {
     "DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME": None,
     # Use a separate path for handling subscriptions.
     "SUBSCRIPTION_PATH": None,
-    # Set to True to enable GraphiQL headers editor tab
+    # By default GraphiQL headers editor tab is enabled, set to False to hide it
     # This sets headerEditorEnabled GraphiQL option, for details go to
     # https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
-    "GRAPHIQL_HEADER_EDITOR_ENABLED": False,
+    "GRAPHIQL_HEADER_EDITOR_ENABLED": True,
 }
 
 if settings.DEBUG:

--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -61,17 +61,29 @@
   var fetchURL = locationQuery(otherParams);
 
   // Defines a GraphQL fetcher using the fetch API.
-  function httpClient(graphQLParams) {
-    var headers = {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    };
+  function httpClient(graphQLParams, opts = { headers: {} }) {
+    let headers = opts.headers;
+    // Convert headers to an object.
+    if (typeof headers === 'string') {
+      headers = JSON.parse(opts.headers);
+    }
     if (csrftoken) {
-      headers["X-CSRFToken"] = csrftoken;
+      Object.assign(
+          {
+            'X-CSRFToken': csrftoken
+          },
+          headers,
+      )
     }
     return fetch(fetchURL, {
       method: "post",
-      headers: headers,
+      headers: Object.assign(
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+          },
+          headers,
+      ),
       body: JSON.stringify(graphQLParams),
       credentials: "include",
     })
@@ -108,7 +120,7 @@
   var activeSubscription = null;
 
   // Define a GraphQL fetcher that can intelligently route queries based on the operation type.
-  function graphQLFetcher(graphQLParams) {
+  function graphQLFetcher(graphQLParams, opts = { headers: {} }) {
     var operationType = getOperationType(graphQLParams);
 
     // If we're about to execute a new operation, and we have an active subscription,
@@ -126,7 +138,7 @@
         },
       };
     } else {
-      return httpClient(graphQLParams);
+      return httpClient(graphQLParams, opts);
     }
   }
 
@@ -173,6 +185,7 @@
     onEditQuery: onEditQuery,
     onEditVariables: onEditVariables,
     onEditOperationName: onEditOperationName,
+    headerEditorEnabled: GRAPHENE_SETTINGS.graphiqlHeaderEditorEnabled || false,
     query: parameters.query,
   };
   if (parameters.variables) {

--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -175,7 +175,7 @@
     onEditQuery: onEditQuery,
     onEditVariables: onEditVariables,
     onEditOperationName: onEditOperationName,
-    headerEditorEnabled: GRAPHENE_SETTINGS.graphiqlHeaderEditorEnabled || true,
+    headerEditorEnabled: GRAPHENE_SETTINGS.graphiqlHeaderEditorEnabled,
     query: parameters.query,
   };
   if (parameters.variables) {

--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -61,29 +61,19 @@
   var fetchURL = locationQuery(otherParams);
 
   // Defines a GraphQL fetcher using the fetch API.
-  function httpClient(graphQLParams, opts = { headers: {} }) {
-    let headers = opts.headers;
-    // Convert headers to an object.
-    if (typeof headers === 'string') {
-      headers = JSON.parse(opts.headers);
+  function httpClient(graphQLParams, opts) {
+    if (typeof opts === 'undefined') {
+      opts = {};
     }
+    var headers = opts.headers || {};
+    headers['Accept'] = headers['Accept'] || 'application/json';
+    headers['Content-Type'] = headers['Content-Type'] || 'application/json';
     if (csrftoken) {
-      Object.assign(
-          {
-            'X-CSRFToken': csrftoken
-          },
-          headers,
-      )
+      headers['X-CSRFToken'] = csrftoken
     }
     return fetch(fetchURL, {
       method: "post",
-      headers: Object.assign(
-          {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-          },
-          headers,
-      ),
+      headers: headers,
       body: JSON.stringify(graphQLParams),
       credentials: "include",
     })
@@ -120,7 +110,7 @@
   var activeSubscription = null;
 
   // Define a GraphQL fetcher that can intelligently route queries based on the operation type.
-  function graphQLFetcher(graphQLParams, opts = { headers: {} }) {
+  function graphQLFetcher(graphQLParams, opts) {
     var operationType = getOperationType(graphQLParams);
 
     // If we're about to execute a new operation, and we have an active subscription,

--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -175,7 +175,7 @@
     onEditQuery: onEditQuery,
     onEditVariables: onEditVariables,
     onEditOperationName: onEditOperationName,
-    headerEditorEnabled: GRAPHENE_SETTINGS.graphiqlHeaderEditorEnabled || false,
+    headerEditorEnabled: GRAPHENE_SETTINGS.graphiqlHeaderEditorEnabled || true,
     query: parameters.query,
   };
   if (parameters.variables) {

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -45,9 +45,7 @@ add "&raw" to the end of the URL within a browser.
     {% if subscription_path %}
       subscriptionPath: "{{subscription_path}}",
     {% endif %}
-    {% if header_editor_enabled %}
-      graphiqlHeaderEditorEnabled: {{ graphiql_header_editor_enabled}},
-    {% endif %}
+      graphiqlHeaderEditorEnabled: {{ graphiql_header_editor_enabled|yesno:"true,false" }},
     };
   </script>
   <script src="{% static 'graphene_django/graphiql.js' %}"></script>

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -46,7 +46,7 @@ add "&raw" to the end of the URL within a browser.
       subscriptionPath: "{{subscription_path}}",
     {% endif %}
     {% if header_editor_enabled %}
-      graphiqlHeaderEditorEnabled: "{{ graphiql_header_editor_enabled}}",
+      graphiqlHeaderEditorEnabled: {{ graphiql_header_editor_enabled}},
     {% endif %}
     };
   </script>

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -45,6 +45,9 @@ add "&raw" to the end of the URL within a browser.
     {% if subscription_path %}
       subscriptionPath: "{{subscription_path}}",
     {% endif %}
+    {% if header_editor_enabled %}
+      graphiqlHeaderEditorEnabled: "{{ graphiql_header_editor_enabled}}",
+    {% endif %}
     };
   </script>
   <script src="{% static 'graphene_django/graphiql.js' %}"></script>

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -167,6 +167,8 @@ class GraphQLView(View):
                     subscriptions_transport_ws_sri=self.subscriptions_transport_ws_sri,
                     # The SUBSCRIPTION_PATH setting.
                     subscription_path=self.subscription_path,
+                    # GraphiQL headers tab,
+                    graphiql_header_editor_enabled=graphene_settings.GRAPHIQL_HEADER_EDITOR_ENABLED,
                 )
 
             if self.batch:


### PR DESCRIPTION
* add GRAPHIQL_HEADER_EDITOR_ENABLED setting with False default
* use GRAPHIQL_HEADER_EDITOR_ENABLED to set headerEditorEnabled GraphiQL option
* update graphQLFetcher and httpClient in static/graphiql.js to support custom query/mutation headers

Making use of https://github.com/graphql/graphiql/pull/1543 this PR introduces ability to set custom headers in GraphiQL once `GRAPHIQL_HEADER_EDITOR_ENABLED` setting is changed to `True`.

This should resolve #850

Probably some docs for this functionality have to be added (and maybe a test).