### PR TITLE
Add converter for django 3.1 JSONField

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        django: ["1.11", "2.2", "3.0"]
+        django: ["1.11", "2.2", "3.0", "3.1"]
         python-version: ["3.6", "3.7", "3.8"]
         include:
           - django: "1.11"

--- a/graphene_django/compat.py
+++ b/graphene_django/compat.py
@@ -8,8 +8,14 @@ try:
     from django.contrib.postgres.fields import (
         ArrayField,
         HStoreField,
-        JSONField,
+        JSONField as PGJSONField,
         RangeField,
     )
 except ImportError:
-    ArrayField, HStoreField, JSONField, RangeField = (MissingType,) * 4
+    ArrayField, HStoreField, PGJSONField, RangeField = (MissingType,) * 4
+
+try:
+    # JSONField is only available from Django 3.1
+    from django.contrib.fields import JSONField
+except ImportError:
+    JSONField = MissingType

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -24,7 +24,7 @@ from graphene.utils.str_converters import to_camel_case
 from graphql import assert_valid_name
 
 from .settings import graphene_settings
-from .compat import ArrayField, HStoreField, JSONField, RangeField
+from .compat import ArrayField, HStoreField, JSONField, PGJSONField, RangeField
 from .fields import DjangoListField, DjangoConnectionField
 from .utils import import_single_dispatch
 from .utils.str_converters import to_const
@@ -267,8 +267,9 @@ def convert_postgres_array_to_list(field, registry=None):
 
 
 @convert_django_field.register(HStoreField)
+@convert_django_field.register(PGJSONField)
 @convert_django_field.register(JSONField)
-def convert_postgres_field_to_string(field, registry=None):
+def convert_pg_and_json_field_to_string(field, registry=None):
     return JSONString(description=field.help_text, required=not field.null)
 
 

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -11,7 +11,14 @@ from graphene.relay import ConnectionField, Node
 from graphene.types.datetime import Date, DateTime, Time
 from graphene.types.json import JSONString
 
-from ..compat import ArrayField, HStoreField, JSONField, MissingType, RangeField
+from ..compat import (
+    ArrayField,
+    HStoreField,
+    JSONField,
+    PGJSONField,
+    MissingType,
+    RangeField,
+)
 from ..converter import (
     convert_django_field,
     convert_django_field_with_choices,
@@ -348,8 +355,13 @@ def test_should_postgres_hstore_convert_string():
     assert_conversion(HStoreField, JSONString)
 
 
-@pytest.mark.skipif(JSONField is MissingType, reason="JSONField should exist")
+@pytest.mark.skipif(PGJSONField is MissingType, reason="PGJSONField should exist")
 def test_should_postgres_json_convert_string():
+    assert_conversion(PGJSONField, JSONString)
+
+
+@pytest.mark.skipif(JSONField is MissingType, reason="JSONField should exist")
+def test_should_json_convert_string():
     assert_conversion(JSONField, JSONString)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,35,36,37,38}-django{111,20,21,22,master},
-    py{36,37,38}-django30,
+    py{36,37,38}-django{30,31},
     black,flake8
 
 [gh-actions]
@@ -18,6 +18,7 @@ DJANGO =
     2.1: django21
     2.2: django22
     3.0: django30
+    3.1: django31
     master: djangomaster
 
 [testenv]
@@ -33,6 +34,7 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
     django30: Django>=3.0a1,<3.1
+    django31: Django>=3.1,<3.2
     djangomaster: https://github.com/django/django/archive/master.zip
 commands = {posargs:py.test --cov=graphene_django graphene_django examples}
 


### PR DESCRIPTION
Should probably wait until django 3.1 is released and possible to add to the test matrix.

Also found #303  thread suggesting people have a use case for converting JSONField (django 3.1, django_mysql and postgres ones) to `GenericScalar`. I'm not sure what is most common.