### PR TITLE
Fix docs testing for GRAPHQL_SCHEMA (#1020)

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -16,7 +16,12 @@ Usage:
 
     from graphene_django.utils.testing import GraphQLTestCase
 
+    from my_fancy.schema import schema
+
+
     class MyFancyTestCase(GraphQLTestCase):
+        GRAPHQL_SCHEMA = schema
+
         def test_some_query(self):
             response = self.query(
                 '''


### PR DESCRIPTION
Resolve error: "AttributeError: Variable GRAPHQL_SCHEMA not defined in
GraphQLTestCase." and issue https://github.com/graphql-python/graphene-django/issues/1020