### PR TITLE
BUGFIX: don't filter out lookup_field as input (required for update)

### DIFF
--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -36,7 +36,8 @@ def fields_for_serializer(
                 name in exclude_fields,
                 field.write_only
                 and not is_input,  # don't show write_only fields in Query
-                field.read_only and is_input
+                field.read_only
+                and is_input
                 and lookup_field != name,  # don't show read_only fields in Input
             ]
         )

--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -26,6 +26,7 @@ def fields_for_serializer(
     exclude_fields,
     is_input=False,
     convert_choices_to_enum=True,
+    lookup_field=None,
 ):
     fields = OrderedDict()
     for name, field in serializer.fields.items():
@@ -35,7 +36,8 @@ def fields_for_serializer(
                 name in exclude_fields,
                 field.write_only
                 and not is_input,  # don't show write_only fields in Query
-                field.read_only and is_input,  # don't show read_only fields in Input
+                field.read_only and is_input
+                and lookup_field != name,  # don't show read_only fields in Input
             ]
         )
 
@@ -90,6 +92,7 @@ class SerializerMutation(ClientIDMutation):
             exclude_fields,
             is_input=True,
             convert_choices_to_enum=convert_choices_to_enum,
+            lookup_field=lookup_field,
         )
         output_fields = fields_for_serializer(
             serializer,
@@ -97,6 +100,7 @@ class SerializerMutation(ClientIDMutation):
             exclude_fields,
             is_input=False,
             convert_choices_to_enum=convert_choices_to_enum,
+            lookup_field=lookup_field,
         )
 
         _meta = SerializerMutationOptions(cls)

--- a/graphene_django/rest_framework/tests/test_mutation.py
+++ b/graphene_django/rest_framework/tests/test_mutation.py
@@ -143,17 +143,20 @@ def test_write_only_field_using_extra_kwargs():
 
 def test_read_only_fields():
     class ReadOnlyFieldModelSerializer(serializers.ModelSerializer):
+        id = serializers.CharField(read_only=True)
         cool_name = serializers.CharField(read_only=True)
 
         class Meta:
             model = MyFakeModelWithPassword
-            fields = ["cool_name", "password"]
+            lookup_field = "id"
+            fields = ["id", "cool_name", "password"]
 
     class MyMutation(SerializerMutation):
         class Meta:
             serializer_class = ReadOnlyFieldModelSerializer
 
     assert "password" in MyMutation.Input._meta.fields
+    assert "id" in MyMutation.Input._meta.fields
     assert (
         "cool_name" not in MyMutation.Input._meta.fields
     ), "'cool_name' is read_only field and shouldn't be on arguments"


### PR DESCRIPTION
When using  `SerializerMutation` the pkey/lookup field is filtered out. see (https://github.com/graphql-python/graphene-django/issues/906). It was introduced by https://github.com/graphql-python/graphene-django/pull/882.

This seems incorrect. https://github.com/graphql-python/graphene-django/blob/ac1f9ac360138c7773774a61dd39da0e1d510425/graphene_django/rest_framework/mutation.py#L120 is using lookup field to determine if we are updating or creating. Because of https://github.com/graphql-python/graphene-django/pull/882 primary key fields are treated as read-only and can never be used for lookup. We need to allow lookup_field in input.

The workaround https://github.com/graphql-python/graphene-django/issues/906#issuecomment-602078174 does not work with relay. (Id field are typically numeric vs string for relay ids)