### PR TITLE
Handle database transactions

### DIFF
--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -229,3 +229,29 @@ This argument is also sent back to the client with the mutation result
 (you do not have to do anything). For services that manage
 a pool of many GraphQL requests in bulk, the ``clientIDMutation``
 allows you to match up a specific mutation with the response.
+
+
+
+Django Database Transactions
+----------------------------
+
+Django gives you a few ways to control how database transactions are managed.
+
+Tying transactions to HTTP requests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A common way to handle transactions in Django is to wrap each request in a transaction.
+Set ``ATOMIC_REQUESTS`` settings to ``True`` in the configuration of each database for
+which you want to enable this behavior.
+
+It works like this. Before calling ``GraphQLView`` Django starts a transaction. If the
+response is produced without problems, Django commits the transaction. If the view, a
+``DjangoFormMutation`` or a ``DjangoModelFormMutation`` produces an exception, Django
+rolls back the transaction.
+
+.. warning::
+
+    While the simplicity of this transaction model is appealing, it also makes it
+    inefficient when traffic increases. Opening a transaction for every request has some
+    overhead. The impact on performance depends on the query patterns of your application
+    and on how well your database handles locking.

--- a/graphene_django/constants.py
+++ b/graphene_django/constants.py
@@ -1,0 +1,1 @@
+MUTATION_ERRORS_FLAG = "graphene_mutation_has_errors"

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -45,6 +45,7 @@ DEFAULTS = {
     # This sets headerEditorEnabled GraphiQL option, for details go to
     # https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
     "GRAPHIQL_HEADER_EDITOR_ENABLED": True,
+    "ATOMIC_MUTATIONS": False,
 }
 
 if settings.DEBUG:

--- a/graphene_django/tests/forms.py
+++ b/graphene_django/tests/forms.py
@@ -1,0 +1,16 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from .models import Pet
+
+
+class PetForm(forms.ModelForm):
+    class Meta:
+        model = Pet
+        fields = "__all__"
+
+    def clean_age(self):
+        age = self.cleaned_data["age"]
+        if age >= 99:
+            raise ValidationError("Too old")
+        return age

--- a/graphene_django/tests/mutations.py
+++ b/graphene_django/tests/mutations.py
@@ -1,0 +1,18 @@
+from graphene import Field
+
+from graphene_django.forms.mutation import DjangoFormMutation, DjangoModelFormMutation
+
+from .forms import PetForm
+from .types import PetType
+
+
+class PetFormMutation(DjangoFormMutation):
+    class Meta:
+        form_class = PetForm
+
+
+class PetMutation(DjangoModelFormMutation):
+    pet = Field(PetType)
+
+    class Meta:
+        form_class = PetForm

--- a/graphene_django/tests/schema_view.py
+++ b/graphene_django/tests/schema_view.py
@@ -1,6 +1,8 @@
 import graphene
 from graphene import ObjectType, Schema
 
+from .mutations import PetFormMutation, PetMutation
+
 
 class QueryRoot(ObjectType):
 
@@ -19,6 +21,8 @@ class QueryRoot(ObjectType):
 
 
 class MutationRoot(ObjectType):
+    pet_form_mutation = PetFormMutation.Field()
+    pet_mutation = PetMutation.Field()
     write_test = graphene.Field(QueryRoot)
 
     def resolve_write_test(self, info):

--- a/graphene_django/tests/test_views.py
+++ b/graphene_django/tests/test_views.py
@@ -568,335 +568,263 @@ def test_passes_request_into_context_request(client):
     assert response_json(response) == {"data": {"request": "testing"}}
 
 
+@patch("graphene_django.settings.graphene_settings.ATOMIC_MUTATIONS", False)
+@patch.dict(
+    connection.settings_dict, {"ATOMIC_MUTATIONS": False, "ATOMIC_REQUESTS": True}
+)
 def test_form_mutation_multiple_creation_invalid_atomic_request(client):
-    old_atomic_mutations = connection.settings_dict.get("ATOMIC_MUTATIONS", False)
-    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
-    old_graphene_atomic_mutations = graphene_settings.ATOMIC_MUTATIONS
-    try:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = False
-        connection.settings_dict["ATOMIC_REQUESTS"] = True
-        graphene_settings.ATOMIC_MUTATIONS = False
-
-        query = """
-        mutation PetMutations {
-            petFormMutation1: petFormMutation(input: { name: "Mia", age: 99 }) {
-                errors {
-                    field
-                    messages
-                }
-            }
-            petFormMutation2: petFormMutation(input: { name: "Enzo", age: 0 }) {
-                errors {
-                    field
-                    messages
-                }
+    query = """
+    mutation PetMutations {
+        petFormMutation1: petFormMutation(input: { name: "Mia", age: 99 }) {
+            errors {
+                field
+                messages
             }
         }
-        """
+        petFormMutation2: petFormMutation(input: { name: "Enzo", age: 0 }) {
+            errors {
+                field
+                messages
+            }
+        }
+    }
+    """
 
-        response = client.post(url_string(query=query))
-        content = response_json(response)
+    response = client.post(url_string(query=query))
+    content = response_json(response)
 
-        assert "errors" not in content
+    assert "errors" not in content
 
-        assert content["data"]["petFormMutation1"]["errors"] == [
-            {"field": "age", "messages": ["Too old"]}
-        ]
+    assert content["data"]["petFormMutation1"]["errors"] == [
+        {"field": "age", "messages": ["Too old"]}
+    ]
 
-        assert content["data"]["petFormMutation2"]["errors"] == []
+    assert content["data"]["petFormMutation2"]["errors"] == []
 
-        assert Pet.objects.count() == 0
-
-    finally:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = old_atomic_mutations
-        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
-        graphene_settings.ATOMIC_MUTATIONS = old_graphene_atomic_mutations
+    assert Pet.objects.count() == 0
 
 
+@patch("graphene_django.settings.graphene_settings.ATOMIC_MUTATIONS", False)
+@patch.dict(
+    connection.settings_dict, {"ATOMIC_MUTATIONS": True, "ATOMIC_REQUESTS": False}
+)
 def test_form_mutation_multiple_creation_invalid_atomic_mutation_1(client):
-    old_atomic_mutations = connection.settings_dict.get("ATOMIC_MUTATIONS", False)
-    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
-    old_graphene_atomic_mutations = graphene_settings.ATOMIC_MUTATIONS
-    try:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = True
-        connection.settings_dict["ATOMIC_REQUESTS"] = False
-        graphene_settings.ATOMIC_MUTATIONS = False
-
-        query = """
-        mutation PetMutations {
-            petFormMutation1: petFormMutation(input: { name: "Mia", age: 99 }) {
-                errors {
-                    field
-                    messages
-                }
-            }
-            petFormMutation2: petFormMutation(input: { name: "Enzo", age: 0 }) {
-                errors {
-                    field
-                    messages
-                }
+    query = """
+    mutation PetMutations {
+        petFormMutation1: petFormMutation(input: { name: "Mia", age: 99 }) {
+            errors {
+                field
+                messages
             }
         }
-        """
+        petFormMutation2: petFormMutation(input: { name: "Enzo", age: 0 }) {
+            errors {
+                field
+                messages
+            }
+        }
+    }
+    """
 
-        response = client.post(url_string(query=query))
-        content = response_json(response)
+    response = client.post(url_string(query=query))
+    content = response_json(response)
 
-        assert "errors" not in content
+    assert "errors" not in content
 
-        assert content["data"]["petFormMutation1"]["errors"] == [
-            {"field": "age", "messages": ["Too old"]}
-        ]
+    assert content["data"]["petFormMutation1"]["errors"] == [
+        {"field": "age", "messages": ["Too old"]}
+    ]
 
-        assert content["data"]["petFormMutation2"]["errors"] == []
+    assert content["data"]["petFormMutation2"]["errors"] == []
 
-        assert Pet.objects.count() == 0
-
-    finally:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = old_atomic_mutations
-        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
-        graphene_settings.ATOMIC_MUTATIONS = old_graphene_atomic_mutations
+    assert Pet.objects.count() == 0
 
 
+@patch("graphene_django.settings.graphene_settings.ATOMIC_MUTATIONS", True)
+@patch.dict(
+    connection.settings_dict, {"ATOMIC_MUTATIONS": False, "ATOMIC_REQUESTS": False}
+)
 def test_form_mutation_multiple_creation_invalid_atomic_mutation_2(client):
-    old_atomic_mutations = connection.settings_dict.get("ATOMIC_MUTATIONS", False)
-    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
-    old_graphene_atomic_mutations = graphene_settings.ATOMIC_MUTATIONS
-    try:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = False
-        connection.settings_dict["ATOMIC_REQUESTS"] = False
-        graphene_settings.ATOMIC_MUTATIONS = True
-
-        query = """
-        mutation PetMutations {
-            petFormMutation1: petFormMutation(input: { name: "Mia", age: 99 }) {
-                errors {
-                    field
-                    messages
-                }
-            }
-            petFormMutation2: petFormMutation(input: { name: "Enzo", age: 0 }) {
-                errors {
-                    field
-                    messages
-                }
+    query = """
+    mutation PetMutations {
+        petFormMutation1: petFormMutation(input: { name: "Mia", age: 99 }) {
+            errors {
+                field
+                messages
             }
         }
-        """
+        petFormMutation2: petFormMutation(input: { name: "Enzo", age: 0 }) {
+            errors {
+                field
+                messages
+            }
+        }
+    }
+    """
 
-        response = client.post(url_string(query=query))
-        content = response_json(response)
+    response = client.post(url_string(query=query))
+    content = response_json(response)
 
-        assert "errors" not in content
+    assert "errors" not in content
 
-        assert content["data"]["petFormMutation1"]["errors"] == [
-            {"field": "age", "messages": ["Too old"]}
-        ]
+    assert content["data"]["petFormMutation1"]["errors"] == [
+        {"field": "age", "messages": ["Too old"]}
+    ]
 
-        assert content["data"]["petFormMutation2"]["errors"] == []
+    assert content["data"]["petFormMutation2"]["errors"] == []
 
-        assert Pet.objects.count() == 0
-
-    finally:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = old_atomic_mutations
-        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
-        graphene_settings.ATOMIC_MUTATIONS = old_graphene_atomic_mutations
+    assert Pet.objects.count() == 0
 
 
+@patch("graphene_django.settings.graphene_settings.ATOMIC_MUTATIONS", False)
+@patch.dict(
+    connection.settings_dict, {"ATOMIC_MUTATIONS": False, "ATOMIC_REQUESTS": False}
+)
 def test_form_mutation_multiple_creation_invalid_non_atomic(client):
-    old_atomic_mutations = connection.settings_dict.get("ATOMIC_MUTATIONS", False)
-    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
-    old_graphene_atomic_mutations = graphene_settings.ATOMIC_MUTATIONS
-    try:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = False
-        connection.settings_dict["ATOMIC_REQUESTS"] = False
-        graphene_settings.ATOMIC_MUTATIONS = False
-
-        query = """
-        mutation PetMutations {
-            petFormMutation1: petFormMutation(input: { name: "Mia", age: 99 }) {
-                errors {
-                    field
-                    messages
-                }
-            }
-            petFormMutation2: petFormMutation(input: { name: "Enzo", age: 0 }) {
-                errors {
-                    field
-                    messages
-                }
+    query = """
+    mutation PetMutations {
+        petFormMutation1: petFormMutation(input: { name: "Mia", age: 99 }) {
+            errors {
+                field
+                messages
             }
         }
-        """
+        petFormMutation2: petFormMutation(input: { name: "Enzo", age: 0 }) {
+            errors {
+                field
+                messages
+            }
+        }
+    }
+    """
 
-        response = client.post(url_string(query=query))
-        content = response_json(response)
+    response = client.post(url_string(query=query))
+    content = response_json(response)
 
-        assert "errors" not in content
+    assert "errors" not in content
 
-        assert content["data"]["petFormMutation1"]["errors"] == [
-            {"field": "age", "messages": ["Too old"]}
-        ]
+    assert content["data"]["petFormMutation1"]["errors"] == [
+        {"field": "age", "messages": ["Too old"]}
+    ]
 
-        assert content["data"]["petFormMutation2"]["errors"] == []
+    assert content["data"]["petFormMutation2"]["errors"] == []
 
-        assert Pet.objects.count() == 1
+    assert Pet.objects.count() == 1
 
-        pet = Pet.objects.get()
-        assert pet.name == "Enzo"
-        assert pet.age == 0
-
-    finally:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = old_atomic_mutations
-        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
-        graphene_settings.ATOMIC_MUTATIONS = old_graphene_atomic_mutations
+    pet = Pet.objects.get()
+    assert pet.name == "Enzo"
+    assert pet.age == 0
 
 
+@patch("graphene_django.settings.graphene_settings.ATOMIC_MUTATIONS", False)
+@patch.dict(
+    connection.settings_dict, {"ATOMIC_MUTATIONS": False, "ATOMIC_REQUESTS": True}
+)
 def test_model_form_mutation_multiple_creation_invalid_atomic_request(client):
-    old_atomic_mutations = connection.settings_dict.get("ATOMIC_MUTATIONS", False)
-    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
-    old_graphene_atomic_mutations = graphene_settings.ATOMIC_MUTATIONS
-    try:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = False
-        connection.settings_dict["ATOMIC_REQUESTS"] = True
-        graphene_settings.ATOMIC_MUTATIONS = False
-
-        query = """
-        mutation PetMutations {
-            petMutation1: petMutation(input: { name: "Mia", age: 99 }) {
-                pet {
-                    name
-                    age
-                }
-                errors {
-                    field
-                    messages
-                }
+    query = """
+    mutation PetMutations {
+        petMutation1: petMutation(input: { name: "Mia", age: 99 }) {
+            pet {
+                name
+                age
             }
-            petMutation2: petMutation(input: { name: "Enzo", age: 0 }) {
-                pet {
-                    name
-                    age
-                }
-                errors {
-                    field
-                    messages
-                }
+            errors {
+                field
+                messages
             }
         }
-        """
+        petMutation2: petMutation(input: { name: "Enzo", age: 0 }) {
+            pet {
+                name
+                age
+            }
+            errors {
+                field
+                messages
+            }
+        }
+    }
+    """
 
-        response = client.post(url_string(query=query))
-        content = response_json(response)
+    response = client.post(url_string(query=query))
+    content = response_json(response)
 
-        assert "errors" not in content
+    assert "errors" not in content
 
-        assert content["data"]["petMutation1"]["pet"] is None
-        assert content["data"]["petMutation1"]["errors"] == [
-            {"field": "age", "messages": ["Too old"]}
-        ]
+    assert content["data"]["petMutation1"]["pet"] is None
+    assert content["data"]["petMutation1"]["errors"] == [
+        {"field": "age", "messages": ["Too old"]}
+    ]
 
-        assert content["data"]["petMutation2"]["pet"] == {"name": "Enzo", "age": 0}
+    assert content["data"]["petMutation2"]["pet"] == {"name": "Enzo", "age": 0}
 
-        assert Pet.objects.count() == 0
-
-    finally:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = old_atomic_mutations
-        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
-        graphene_settings.ATOMIC_MUTATIONS = old_graphene_atomic_mutations
+    assert Pet.objects.count() == 0
 
 
+@patch("graphene_django.settings.graphene_settings.ATOMIC_MUTATIONS", False)
+@patch.dict(
+    connection.settings_dict, {"ATOMIC_MUTATIONS": False, "ATOMIC_REQUESTS": False}
+)
 def test_model_form_mutation_multiple_creation_invalid_non_atomic(client):
-    old_atomic_mutations = connection.settings_dict.get("ATOMIC_MUTATIONS", False)
-    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
-    old_graphene_atomic_mutations = graphene_settings.ATOMIC_MUTATIONS
-    try:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = False
-        connection.settings_dict["ATOMIC_REQUESTS"] = False
-        graphene_settings.ATOMIC_MUTATIONS = False
-
-        query = """
-        mutation PetMutations {
-            petMutation1: petMutation(input: { name: "Mia", age: 99 }) {
-                pet {
-                    name
-                    age
-                }
-                errors {
-                    field
-                    messages
-                }
+    query = """
+    mutation PetMutations {
+        petMutation1: petMutation(input: { name: "Mia", age: 99 }) {
+            pet {
+                name
+                age
             }
-            petMutation2: petMutation(input: { name: "Enzo", age: 0 }) {
-                pet {
-                    name
-                    age
-                }
-                errors {
-                    field
-                    messages
-                }
+            errors {
+                field
+                messages
             }
         }
-        """
+        petMutation2: petMutation(input: { name: "Enzo", age: 0 }) {
+            pet {
+                name
+                age
+            }
+            errors {
+                field
+                messages
+            }
+        }
+    }
+    """
 
-        response = client.post(url_string(query=query))
-        content = response_json(response)
+    response = client.post(url_string(query=query))
+    content = response_json(response)
 
-        assert "errors" not in content
+    assert "errors" not in content
 
-        assert content["data"]["petMutation1"]["pet"] is None
-        assert content["data"]["petMutation1"]["errors"] == [
-            {"field": "age", "messages": ["Too old"]}
-        ]
+    assert content["data"]["petMutation1"]["pet"] is None
+    assert content["data"]["petMutation1"]["errors"] == [
+        {"field": "age", "messages": ["Too old"]}
+    ]
 
-        assert content["data"]["petMutation2"]["pet"] == {"name": "Enzo", "age": 0}
+    assert content["data"]["petMutation2"]["pet"] == {"name": "Enzo", "age": 0}
 
-        assert Pet.objects.count() == 1
+    assert Pet.objects.count() == 1
 
-        pet = Pet.objects.get()
-        assert pet.name == "Enzo"
-        assert pet.age == 0
-
-    finally:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = old_atomic_mutations
-        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
-        graphene_settings.ATOMIC_MUTATIONS = old_graphene_atomic_mutations
+    pet = Pet.objects.get()
+    assert pet.name == "Enzo"
+    assert pet.age == 0
 
 
 @patch("graphene_django.utils.utils.transaction.set_rollback")
+@patch("graphene_django.settings.graphene_settings.ATOMIC_MUTATIONS", False)
+@patch.dict(
+    connection.settings_dict, {"ATOMIC_MUTATIONS": False, "ATOMIC_REQUESTS": True}
+)
 def test_query_errors_atomic_request(set_rollback_mock, client):
-    old_atomic_mutations = connection.settings_dict.get("ATOMIC_MUTATIONS", False)
-    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
-    old_graphene_atomic_mutations = graphene_settings.ATOMIC_MUTATIONS
-    try:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = False
-        connection.settings_dict["ATOMIC_REQUESTS"] = True
-        graphene_settings.ATOMIC_MUTATIONS = False
-
-        client.get(url_string(query="force error"))
-        set_rollback_mock.assert_called_once_with(True)
-
-    finally:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = old_atomic_mutations
-        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
-        graphene_settings.ATOMIC_MUTATIONS = old_graphene_atomic_mutations
+    client.get(url_string(query="force error"))
+    set_rollback_mock.assert_called_once_with(True)
 
 
 @patch("graphene_django.utils.utils.transaction.set_rollback")
+@patch("graphene_django.settings.graphene_settings.ATOMIC_MUTATIONS", False)
+@patch.dict(
+    connection.settings_dict, {"ATOMIC_MUTATIONS": False, "ATOMIC_REQUESTS": False}
+)
 def test_query_errors_non_atomic(set_rollback_mock, client):
-    old_atomic_mutations = connection.settings_dict.get("ATOMIC_MUTATIONS", False)
-    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
-    old_graphene_atomic_mutations = graphene_settings.ATOMIC_MUTATIONS
-    try:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = False
-        connection.settings_dict["ATOMIC_REQUESTS"] = False
-        graphene_settings.ATOMIC_MUTATIONS = False
-
-        client.get(url_string(query="force error"))
-        set_rollback_mock.assert_not_called()
-
-    finally:
-        connection.settings_dict["ATOMIC_MUTATIONS"] = old_atomic_mutations
-        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
-        graphene_settings.ATOMIC_MUTATIONS = old_graphene_atomic_mutations
+    client.get(url_string(query="force error"))
+    set_rollback_mock.assert_not_called()

--- a/graphene_django/tests/test_views.py
+++ b/graphene_django/tests/test_views.py
@@ -2,6 +2,12 @@ import json
 
 import pytest
 
+from mock import patch
+
+from django.db import connection
+
+from .models import Pet
+
 try:
     from urllib import urlencode
 except ImportError:
@@ -558,3 +564,211 @@ def test_passes_request_into_context_request(client):
 
     assert response.status_code == 200
     assert response_json(response) == {"data": {"request": "testing"}}
+
+
+def test_form_mutation_multiple_creation_invalid_atomic_request(client):
+    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
+    try:
+        connection.settings_dict["ATOMIC_REQUESTS"] = True
+
+        query = """
+        mutation PetMutations {
+            petFormMutation1: petFormMutation(input: { name: "Mia", age: 99 }) {
+                errors {
+                    field
+                    messages
+                }
+            }
+            petFormMutation2: petFormMutation(input: { name: "Enzo", age: 0 }) {
+                errors {
+                    field
+                    messages
+                }
+            }
+        }
+        """
+
+        response = client.post(url_string(query=query))
+        content = response_json(response)
+
+        assert "errors" not in content
+
+        assert content["data"]["petFormMutation1"]["errors"] == [
+            {"field": "age", "messages": ["Too old"]}
+        ]
+
+        assert content["data"]["petFormMutation2"]["errors"] == []
+
+        assert Pet.objects.count() == 0
+
+    finally:
+        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
+
+
+def test_form_mutation_multiple_creation_invalid_non_atomic_request(client):
+    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
+    try:
+        connection.settings_dict["ATOMIC_REQUESTS"] = False
+
+        query = """
+        mutation PetMutations {
+            petFormMutation1: petFormMutation(input: { name: "Mia", age: 99 }) {
+                errors {
+                    field
+                    messages
+                }
+            }
+            petFormMutation2: petFormMutation(input: { name: "Enzo", age: 0 }) {
+                errors {
+                    field
+                    messages
+                }
+            }
+        }
+        """
+
+        response = client.post(url_string(query=query))
+        content = response_json(response)
+
+        assert "errors" not in content
+
+        assert content["data"]["petFormMutation1"]["errors"] == [
+            {"field": "age", "messages": ["Too old"]}
+        ]
+
+        assert content["data"]["petFormMutation2"]["errors"] == []
+
+        assert Pet.objects.count() == 1
+
+        pet = Pet.objects.get()
+        assert pet.name == "Enzo"
+        assert pet.age == 0
+
+    finally:
+        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
+
+
+def test_model_form_mutation_multiple_creation_invalid_atomic_request(client):
+    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
+    try:
+        connection.settings_dict["ATOMIC_REQUESTS"] = True
+
+        query = """
+        mutation PetMutations {
+            petMutation1: petMutation(input: { name: "Mia", age: 99 }) {
+                pet {
+                    name
+                    age
+                }
+                errors {
+                    field
+                    messages
+                }
+            }
+            petMutation2: petMutation(input: { name: "Enzo", age: 0 }) {
+                pet {
+                    name
+                    age
+                }
+                errors {
+                    field
+                    messages
+                }
+            }
+        }
+        """
+
+        response = client.post(url_string(query=query))
+        content = response_json(response)
+
+        assert "errors" not in content
+
+        assert content["data"]["petMutation1"]["pet"] is None
+        assert content["data"]["petMutation1"]["errors"] == [
+            {"field": "age", "messages": ["Too old"]}
+        ]
+
+        assert content["data"]["petMutation2"]["pet"] == {"name": "Enzo", "age": 0}
+
+        assert Pet.objects.count() == 0
+
+    finally:
+        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
+
+
+def test_model_form_mutation_multiple_creation_invalid_non_atomic_request(client):
+    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
+    try:
+        connection.settings_dict["ATOMIC_REQUESTS"] = False
+
+        query = """
+        mutation PetMutations {
+            petMutation1: petMutation(input: { name: "Mia", age: 99 }) {
+                pet {
+                    name
+                    age
+                }
+                errors {
+                    field
+                    messages
+                }
+            }
+            petMutation2: petMutation(input: { name: "Enzo", age: 0 }) {
+                pet {
+                    name
+                    age
+                }
+                errors {
+                    field
+                    messages
+                }
+            }
+        }
+        """
+
+        response = client.post(url_string(query=query))
+        content = response_json(response)
+
+        assert "errors" not in content
+
+        assert content["data"]["petMutation1"]["pet"] is None
+        assert content["data"]["petMutation1"]["errors"] == [
+            {"field": "age", "messages": ["Too old"]}
+        ]
+
+        assert content["data"]["petMutation2"]["pet"] == {"name": "Enzo", "age": 0}
+
+        assert Pet.objects.count() == 1
+
+        pet = Pet.objects.get()
+        assert pet.name == "Enzo"
+        assert pet.age == 0
+
+    finally:
+        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
+
+
+@patch("rest_framework.views.transaction.set_rollback")
+def test_query_errors_atomic_request(set_rollback_mock, client):
+    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
+    try:
+        connection.settings_dict["ATOMIC_REQUESTS"] = True
+
+        client.get(url_string(query="force error"))
+        set_rollback_mock.assert_called_once_with(True)
+
+    finally:
+        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests
+
+
+@patch("rest_framework.views.transaction.set_rollback")
+def test_query_errors_non_atomic_request(set_rollback_mock, client):
+    old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
+    try:
+        connection.settings_dict["ATOMIC_REQUESTS"] = False
+
+        client.get(url_string(query="force error"))
+        set_rollback_mock.assert_not_called()
+
+    finally:
+        connection.settings_dict["ATOMIC_REQUESTS"] = old_atomic_requests

--- a/graphene_django/tests/test_views.py
+++ b/graphene_django/tests/test_views.py
@@ -864,7 +864,7 @@ def test_model_form_mutation_multiple_creation_invalid_non_atomic(client):
         graphene_settings.ATOMIC_MUTATIONS = old_graphene_atomic_mutations
 
 
-@patch("rest_framework.views.transaction.set_rollback")
+@patch("graphene_django.utils.utils.transaction.set_rollback")
 def test_query_errors_atomic_request(set_rollback_mock, client):
     old_atomic_mutations = connection.settings_dict.get("ATOMIC_MUTATIONS", False)
     old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]
@@ -883,7 +883,7 @@ def test_query_errors_atomic_request(set_rollback_mock, client):
         graphene_settings.ATOMIC_MUTATIONS = old_graphene_atomic_mutations
 
 
-@patch("rest_framework.views.transaction.set_rollback")
+@patch("graphene_django.utils.utils.transaction.set_rollback")
 def test_query_errors_non_atomic(set_rollback_mock, client):
     old_atomic_mutations = connection.settings_dict.get("ATOMIC_MUTATIONS", False)
     old_atomic_requests = connection.settings_dict["ATOMIC_REQUESTS"]

--- a/graphene_django/tests/types.py
+++ b/graphene_django/tests/types.py
@@ -1,0 +1,9 @@
+from graphene_django.types import DjangoObjectType
+
+from .models import Pet
+
+
+class PetType(DjangoObjectType):
+    class Meta:
+        model = Pet
+        fields = "__all__"

--- a/graphene_django/utils/utils.py
+++ b/graphene_django/utils/utils.py
@@ -1,7 +1,7 @@
 import inspect
 
 import six
-from django.db import models
+from django.db import connection, models, transaction
 from django.db.models.manager import Manager
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
@@ -100,3 +100,9 @@ def import_single_dispatch():
         )
 
     return singledispatch
+
+
+def set_rollback():
+    atomic_requests = connection.settings_dict.get("ATOMIC_REQUESTS", False)
+    if atomic_requests and connection.in_atomic_block:
+        transaction.set_rollback(True)

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -328,8 +328,8 @@ class GraphQLView(View):
                 "operation_name": operation_name,
                 "context_value": self.get_context(request),
                 "middleware": self.get_middleware(request),
-                **extra_options,
             }
+            options.update(extra_options)
 
             if operation_type == "mutation" and (
                 graphene_settings.ATOMIC_MUTATIONS is True

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -321,7 +321,6 @@ class GraphQLView(View):
                 # executor is not a valid argument in all backends
                 extra_options["executor"] = self.executor
 
-            operation_type = document.get_operation_type(operation_name)
             options = {
                 "root_value": self.get_root_value(request),
                 "variable_values": variables,
@@ -331,6 +330,7 @@ class GraphQLView(View):
             }
             options.update(extra_options)
 
+            operation_type = document.get_operation_type(operation_name)
             if operation_type == "mutation" and (
                 graphene_settings.ATOMIC_MUTATIONS is True
                 or connection.settings_dict.get("ATOMIC_MUTATIONS", False) is True

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -17,6 +17,10 @@ from graphql.execution import ExecutionResult
 from graphql.type.schema import GraphQLSchema
 from graphql.execution.middleware import MiddlewareManager
 
+from rest_framework.views import set_rollback
+
+from graphene_django.constants import MUTATION_ERRORS_FLAG
+
 from .settings import graphene_settings
 
 
@@ -203,11 +207,15 @@ class GraphQLView(View):
             request, data, query, variables, operation_name, show_graphiql
         )
 
+        if getattr(request, MUTATION_ERRORS_FLAG, False) is True:
+            set_rollback()
+
         status_code = 200
         if execution_result:
             response = {}
 
             if execution_result.errors:
+                set_rollback()
                 response["errors"] = [
                     self.format_error(e) for e in execution_result.errors
                 ]

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -18,9 +18,8 @@ from graphql.execution import ExecutionResult
 from graphql.type.schema import GraphQLSchema
 from graphql.execution.middleware import MiddlewareManager
 
-from rest_framework.views import set_rollback
-
 from graphene_django.constants import MUTATION_ERRORS_FLAG
+from graphene_django.utils.utils import set_rollback
 
 from .settings import graphene_settings
 


### PR DESCRIPTION
#### Motivation

I was faced with an issue similar to the one described in https://github.com/graphql-python/graphene-django/issues/835 and I decided to solve both use cases.

I updated the project documentation and I also put it below to explain the PR.

## Django Database Transactions

Django gives you a few ways to control how database transactions are managed.

### Tying transactions to HTTP requests

A common way to handle transactions in Django is to wrap each request in a transaction. Set `ATOMIC_REQUESTS` settings to `True` in the configuration of each database for which you want to enable this behavior.

It works like this. Before calling `GraphQLView` Django starts a transaction. If the response is produced without problems, Django commits the transaction. If the view, a `DjangoFormMutation` or a `DjangoModelFormMutation` produces an exception, Django rolls back the transaction.

> **Warning**
>
> While the simplicity of this transaction model is appealing, it also makes it inefficient when traffic increases. Opening a transaction for every request has some overhead. The impact on performance depends on the query patterns of your application and on how well your database handles locking.

Check the next section for a better solution.

### Tying transactions to mutations

A mutation can contain multiple fields, just like a query. There's one important distinction between queries and mutations, other than the name:

> _While query fields are executed in parallel, mutation fields run in series, one after the other._

This means that if we send two `incrementCredits` mutations in one request, the first is guaranteed to finish before the second begins, ensuring that we don't end up with a race condition with ourselves.

On the other hand, if the first `incrementCredits` runs successfully but the second one does not, the operation cannot be retried as it is. That's why is a good idea to run all mutation fields in a transaction, to guarantee all occur or nothing occurs.

To enable this behavior for all databases set the graphene `ATOMIC_MUTATIONS` settings to `True` in your settings file:
```py
GRAPHENE = {
    # ...
    "ATOMIC_MUTATIONS": True,
}
```

On the contrary, if you want to enable this behavior for a specific database, set `ATOMIC_MUTATIONS` to `True` in your database settings:
```py
DATABASES = {
    "default": {
        # ...
        "ATOMIC_MUTATIONS": True,
    },
    # ...
}
```

Now, given the following example mutation:
```py
mutation IncreaseCreditsTwice {

    increaseCredits1: increaseCredits(input: { amount: 10 }) {
        balance
        errors {
            field
            messages
        }
    }

    increaseCredits2: increaseCredits(input: { amount: -1 }) {
        balance
        errors {
            field
            messages
        }
    }

}
```

The server is going to return something like:
```py
{
    "data": {
        "increaseCredits1": {
            "balance": 10.0,
            "errors": []
        },
        "increaseCredits2": {
            "balance": null,
            "errors": [
                {
                    "field": "amount",
                    "message": "Amount should be a positive number"
                }
            ]
        },
    }
}
```

But the balance will remain the same.