### PR TITLE
Restrict DjangoRestFramework version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     -e.[test]
     psycopg2-binary
     django111: Django>=1.11,<2.0
+    django111: djangorestframework<3.12
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0


### PR DESCRIPTION
Fixes tests for Django 1.11