### PR TITLE
fix `variables` key in body

### DIFF
--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -45,7 +45,7 @@ def graphql_query(
     if variables:
         body["variables"] = variables
     if input_data:
-        if variables in body:
+        if "variables" in body:
             body["variables"]["input"] = input_data
         else:
             body["variables"] = {"input": input_data}


### PR DESCRIPTION
There is a typo on checking if the key `variables` already exists in the body request.