### PR TITLE
Fix 1061: DjangoListField should not cache queries

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -44,7 +44,7 @@ class DjangoListField(Field):
         return self._underlying_type._meta.model
 
     def get_default_queryset(self):
-        return self.model._default_manager.get_queryset()
+        return self.model._default_manager  # .get_queryset()
 
     @staticmethod
     def list_resolver(
@@ -52,7 +52,7 @@ class DjangoListField(Field):
     ):
         queryset = maybe_queryset(resolver(root, info, **args))
         if queryset is None:
-            queryset = default_queryset
+            queryset = maybe_queryset(default_queryset)
 
         if isinstance(queryset, QuerySet):
             # Pass queryset to the DjangoObjectType get_queryset method

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -43,16 +43,16 @@ class DjangoListField(Field):
     def model(self):
         return self._underlying_type._meta.model
 
-    def get_default_queryset(self):
-        return self.model._default_manager  # .get_queryset()
+    def get_manager(self):
+        return self.model._default_manager
 
     @staticmethod
     def list_resolver(
-        django_object_type, resolver, default_queryset, root, info, **args
+        django_object_type, resolver, default_manager, root, info, **args
     ):
         queryset = maybe_queryset(resolver(root, info, **args))
         if queryset is None:
-            queryset = maybe_queryset(default_queryset)
+            queryset = maybe_queryset(default_manager)
 
         if isinstance(queryset, QuerySet):
             # Pass queryset to the DjangoObjectType get_queryset method
@@ -69,7 +69,7 @@ class DjangoListField(Field):
             self.list_resolver,
             django_object_type,
             parent_resolver,
-            self.get_default_queryset(),
+            self.get_manager(),
         )
 
 

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -66,10 +66,7 @@ class DjangoListField(Field):
             _type = _type.of_type
         django_object_type = _type.of_type.of_type
         return partial(
-            self.list_resolver,
-            django_object_type,
-            parent_resolver,
-            self.get_manager(),
+            self.list_resolver, django_object_type, parent_resolver, self.get_manager(),
         )
 
 

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -75,6 +75,39 @@ class TestDjangoListField:
             "reporters": [{"firstName": "Tara"}, {"firstName": "Debra"}]
         }
 
+    def test_list_field_queryset_is_not_cached(self):
+        class Reporter(DjangoObjectType):
+            class Meta:
+                model = ReporterModel
+                fields = ("first_name",)
+
+        class Query(ObjectType):
+            reporters = DjangoListField(Reporter)
+
+        schema = Schema(query=Query)
+
+        query = """
+            query {
+                reporters {
+                    firstName
+                }
+            }
+        """
+
+        result = schema.execute(query)
+        assert not result.errors
+        assert result.data == {"reporters": []}
+
+        ReporterModel.objects.create(first_name="Tara", last_name="West")
+        ReporterModel.objects.create(first_name="Debra", last_name="Payne")
+
+        result = schema.execute(query)
+
+        assert not result.errors
+        assert result.data == {
+            "reporters": [{"firstName": "Tara"}, {"firstName": "Debra"}]
+        }
+
     def test_override_resolver(self):
         class Reporter(DjangoObjectType):
             class Meta:


### PR DESCRIPTION
Attempt to fix #1061

1. test that default functionality should resolve/call queryset at view time
2. `DjangoListField.get_default_queryset` returns a manager and `list_resolver` calls maybe_queryset on default_queryset