### PR TITLE
Fix pagination for 'last' page.

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -147,21 +147,19 @@ class DjangoConnectionField(ConnectionField):
 
         if isinstance(iterable, QuerySet):
             list_length = iterable.count()
-            list_slice_length = (
-                min(max_limit, list_length) if max_limit is not None else list_length
-            )
         else:
             list_length = len(iterable)
-            list_slice_length = (
-                min(max_limit, list_length) if max_limit is not None else list_length
-            )
+
+        list_slice_length = list_length
+        if max_limit is not None and "last" not in args:
+            list_slice_length = min(max_limit, list_length)
 
         # If after is higher than list_length, connection_from_list_slice
         # would try to do a negative slicing which makes django throw an
         # AssertionError
         after = min(get_offset_with_default(args.get("after"), -1) + 1, list_length)
 
-        if max_limit is not None and "first" not in args:
+        if max_limit is not None and "first" not in args and "last" not in args:
             args["first"] = max_limit
 
         connection = connection_from_list_slice(

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -67,6 +67,9 @@ class Reporter(models.Model):
     def some_method(self):
         return 123
 
+    class Meta:
+        ordering = ("id",)
+
 
 class CNNReporterManager(models.Manager):
     def get_queryset(self):


### PR DESCRIPTION
When paginating from the end of the results, the last items were not returned correctly.

Added a test to showcase the issue.