### PR TITLE
Also convert BaseCSVFilter for custom fields

### DIFF
--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -6,6 +6,10 @@ from django.utils.translation import ugettext_lazy as _
 CHOICES = ((1, "this"), (2, _("that")))
 
 
+class Person(models.Model):
+    name = models.CharField(max_length=30)
+
+
 class Pet(models.Model):
     name = models.CharField(max_length=30)
     age = models.PositiveIntegerField()


### PR DESCRIPTION
The PR https://github.com/graphql-python/graphene-django/pull/1070 changed the automatically generated filters to use a lista of the given type instead of forcing a string separated by commas.

This should also apply to custom filters when using `filters.BaseInFilter` for example.