### PR TITLE
improvement: convert decimal field to graphene decimal

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -18,6 +18,7 @@ from graphene import (
     DateTime,
     Date,
     Time,
+    Decimal,
 )
 from graphene.types.json import JSONString
 from graphene.utils.str_converters import to_camel_case
@@ -160,6 +161,10 @@ def convert_field_to_boolean(field, registry=None):
 
 
 @convert_django_field.register(models.DecimalField)
+def convert_field_to_decimal(field, registry=None):
+    return Decimal(description=field.help_text, required=not field.null)
+
+
 @convert_django_field.register(models.FloatField)
 @convert_django_field.register(models.DurationField)
 def convert_field_to_float(field, registry=None):

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -242,6 +242,10 @@ def test_should_float_convert_float():
     assert_conversion(models.FloatField, graphene.Float)
 
 
+def test_should_float_convert_decimal():
+    assert_conversion(models.DecimalField, graphene.Decimal)
+
+
 def test_should_manytomany_convert_connectionorlist():
     registry = Registry()
     dynamic_field = convert_django_field(Reporter._meta.local_many_to_many[0], registry)


### PR DESCRIPTION
Fixes #91 by converting `models.DecimalField` to graphene's `Decimal` type