### PR TITLE
Use the Django TestCase's Client

### DIFF
--- a/graphene_django/tests/test_utils.py
+++ b/graphene_django/tests/test_utils.py
@@ -51,7 +51,9 @@ def test_graphql_test_case_op_name(post_mock):
             pass
 
     tc = TestClass()
+    tc._pre_setup()
     tc.setUpClass()
+
     tc.query("query { }", op_name="QueryName")
     body = json.loads(post_mock.call_args.args[1])
     # `operationName` field from https://graphql.org/learn/serving-over-http/#post-request

--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -1,6 +1,7 @@
 import json
+import warnings
 
-from django.test import TestCase, Client
+from django.test import Client, TestCase
 
 DEFAULT_GRAPHQL_URL = "/graphql/"
 
@@ -96,6 +97,15 @@ class GraphQLTestCase(TestCase):
             client=self.client,
             graphql_url=self.GRAPHQL_URL,
         )
+
+    @property
+    def _client(self):
+        warnings.warn(
+            "Using `_client` is deprecated in favour of `client`.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.client
 
     def assertResponseNoErrors(self, resp, msg=None):
         """

--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -68,12 +68,6 @@ class GraphQLTestCase(TestCase):
     # URL to graphql endpoint
     GRAPHQL_URL = DEFAULT_GRAPHQL_URL
 
-    @classmethod
-    def setUpClass(cls):
-        super(GraphQLTestCase, cls).setUpClass()
-
-        cls._client = Client()
-
     def query(self, query, op_name=None, input_data=None, variables=None, headers=None):
         """
         Args:
@@ -99,7 +93,7 @@ class GraphQLTestCase(TestCase):
             input_data=input_data,
             variables=variables,
             headers=headers,
-            client=self._client,
+            client=self.client,
             graphql_url=self.GRAPHQL_URL,
         )
 

--- a/graphene_django/utils/tests/test_testing.py
+++ b/graphene_django/utils/tests/test_testing.py
@@ -1,0 +1,24 @@
+import pytest
+
+from .. import GraphQLTestCase
+from ...tests.test_types import with_local_registry
+
+
+@with_local_registry
+def test_graphql_test_case_deprecated_client():
+    """
+    Test that `GraphQLTestCase._client`'s should raise pending deprecation warning.
+    """
+
+    class TestClass(GraphQLTestCase):
+        GRAPHQL_SCHEMA = True
+
+        def runTest(self):
+            pass
+
+    tc = TestClass()
+    tc._pre_setup()
+    tc.setUpClass()
+
+    with pytest.warns(PendingDeprecationWarning):
+        tc._client


### PR DESCRIPTION
Use the Django Client test utility instance that Django provides with its TestCase class. This allows GraphQL tests to make use of the stateful client methods like login()

Updated version of https://github.com/graphql-python/graphene-django/pull/886, our oldest open PR.