### PR TITLE
Fix backward compability on GraphQLTestCase._client setter (v2)

### DIFF
--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -100,12 +100,25 @@ class GraphQLTestCase(TestCase):
 
     @property
     def _client(self):
+        pass
+
+    @_client.getter
+    def _client(self):
         warnings.warn(
             "Using `_client` is deprecated in favour of `client`.",
             PendingDeprecationWarning,
             stacklevel=2,
         )
         return self.client
+
+    @_client.setter
+    def _client(self, client):
+        warnings.warn(
+            "Using `_client` is deprecated in favour of `client`.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.client = client
 
     def assertResponseNoErrors(self, resp, msg=None):
         """

--- a/graphene_django/utils/tests/test_testing.py
+++ b/graphene_django/utils/tests/test_testing.py
@@ -2,12 +2,13 @@ import pytest
 
 from .. import GraphQLTestCase
 from ...tests.test_types import with_local_registry
+from django.test import Client
 
 
 @with_local_registry
-def test_graphql_test_case_deprecated_client():
+def test_graphql_test_case_deprecated_client_getter():
     """
-    Test that `GraphQLTestCase._client`'s should raise pending deprecation warning.
+    `GraphQLTestCase._client`' getter should raise pending deprecation warning.
     """
 
     class TestClass(GraphQLTestCase):
@@ -22,3 +23,23 @@ def test_graphql_test_case_deprecated_client():
 
     with pytest.warns(PendingDeprecationWarning):
         tc._client
+
+
+@with_local_registry
+def test_graphql_test_case_deprecated_client_setter():
+    """
+    `GraphQLTestCase._client`' setter should raise pending deprecation warning.
+    """
+
+    class TestClass(GraphQLTestCase):
+        GRAPHQL_SCHEMA = True
+
+        def runTest(self):
+            pass
+
+    tc = TestClass()
+    tc._pre_setup()
+    tc.setUpClass()
+
+    with pytest.warns(PendingDeprecationWarning):
+        tc._client = Client()


### PR DESCRIPTION
I didn't handle backward compatability for setter in https://github.com/graphql-python/graphene-django/pull/1084/files#r549921387 and it seems it caused problems for several users.

Relates to #1088, hopefully fixes it :slightly_smiling_face: 