### PR TITLE
Support "contains" and "overlap" filtering (v2)

### DIFF
--- a/graphene_django/compat.py
+++ b/graphene_django/compat.py
@@ -6,13 +6,16 @@ try:
     # Postgres fields are only available in Django with psycopg2 installed
     # and we cannot have psycopg2 on PyPy
     from django.contrib.postgres.fields import (
+        IntegerRangeField,
         ArrayField,
         HStoreField,
         JSONField as PGJSONField,
         RangeField,
     )
 except ImportError:
-    ArrayField, HStoreField, PGJSONField, RangeField = (MissingType,) * 4
+    IntegerRangeField, ArrayField, HStoreField, PGJSONField, RangeField = (
+        MissingType,
+    ) * 5
 
 try:
     # JSONField is only available from Django 3.1

--- a/graphene_django/filter/tests/conftest.py
+++ b/graphene_django/filter/tests/conftest.py
@@ -1,0 +1,125 @@
+from mock import MagicMock
+import pytest
+
+from django.db import models
+from django.db.models.query import QuerySet
+from django_filters import filters
+from django_filters import FilterSet
+import graphene
+from graphene.relay import Node
+from graphene_django import DjangoObjectType
+from graphene_django.utils import DJANGO_FILTER_INSTALLED
+
+from ...compat import ArrayField
+
+pytestmark = []
+
+if DJANGO_FILTER_INSTALLED:
+    from graphene_django.filter import DjangoFilterConnectionField
+else:
+    pytestmark.append(
+        pytest.mark.skipif(
+            True, reason="django_filters not installed or not compatible"
+        )
+    )
+
+
+@pytest.fixture
+def Event():
+    class Event(models.Model):
+        name = models.CharField(max_length=50)
+        tags = ArrayField(models.CharField(max_length=50))
+
+    return Event
+
+
+@pytest.fixture
+def EventFilterSet(Event):
+
+    from django.contrib.postgres.forms import SimpleArrayField
+
+    class ArrayFilter(filters.Filter):
+        base_field_class = SimpleArrayField
+
+    class EventFilterSet(FilterSet):
+        class Meta:
+            model = Event
+            fields = {
+                "name": ["exact"],
+            }
+
+        tags__contains = ArrayFilter(field_name="tags", lookup_expr="contains")
+        tags__overlap = ArrayFilter(field_name="tags", lookup_expr="overlap")
+
+    return EventFilterSet
+
+
+@pytest.fixture
+def EventType(Event, EventFilterSet):
+    class EventType(DjangoObjectType):
+        class Meta:
+            model = Event
+            interfaces = (Node,)
+            filterset_class = EventFilterSet
+
+    return EventType
+
+
+@pytest.fixture
+def Query(Event, EventType):
+    class Query(graphene.ObjectType):
+        events = DjangoFilterConnectionField(EventType)
+
+        def resolve_events(self, info, **kwargs):
+
+            events = [
+                Event(name="Live Show", tags=["concert", "music", "rock"],),
+                Event(name="Musical", tags=["movie", "music"],),
+                Event(name="Ballet", tags=["concert", "dance"],),
+            ]
+
+            m_queryset = MagicMock(spec=QuerySet)
+            m_queryset.model = Event
+
+            def filter_events(**kwargs):
+                nonlocal events
+                if "tags__contains" in kwargs:
+                    events = list(
+                        filter(
+                            lambda e: set(kwargs["tags__contains"]).issubset(
+                                set(e.tags)
+                            ),
+                            events,
+                        )
+                    )
+                if "tags__overlap" in kwargs:
+                    events = list(
+                        filter(
+                            lambda e: not set(kwargs["tags__overlap"]).isdisjoint(
+                                set(e.tags)
+                            ),
+                            events,
+                        )
+                    )
+
+            def mock_queryset_filter(*args, **kwargs):
+                filter_events(**kwargs)
+                return m_queryset
+
+            def mock_queryset_none(*args, **kwargs):
+                nonlocal events
+                events = []
+                return m_queryset
+
+            def mock_queryset_count(*args, **kwargs):
+                return len(events)
+
+            m_queryset.all.return_value = m_queryset
+            m_queryset.filter.side_effect = mock_queryset_filter
+            m_queryset.none.side_effect = mock_queryset_none
+            m_queryset.count.side_effect = mock_queryset_count
+            m_queryset.__getitem__.side_effect = events.__getitem__
+
+            return m_queryset
+
+    return Query

--- a/graphene_django/filter/tests/test_contains_filter.py
+++ b/graphene_django/filter/tests/test_contains_filter.py
@@ -1,0 +1,82 @@
+import pytest
+
+from graphene import Schema
+
+from ...compat import ArrayField, MissingType
+
+
+@pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
+def test_string_contains_multiple(Event, Query):
+    """
+    Test contains filter on a string field.
+    """
+
+    schema = Schema(query=Query)
+
+    query = """
+    query {
+        events (tags_Contains: ["concert", "music"]) {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+    """
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data["events"]["edges"] == [
+        {"node": {"name": "Live Show"}},
+    ]
+
+
+@pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
+def test_string_contains_one(Event, Query):
+    """
+    Test contains filter on a string field.
+    """
+
+    schema = Schema(query=Query)
+
+    query = """
+    query {
+        events (tags_Contains: ["music"]) {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+    """
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data["events"]["edges"] == [
+        {"node": {"name": "Live Show"}},
+        {"node": {"name": "Musical"}},
+    ]
+
+
+@pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
+def test_string_contains_none(Event, Query):
+    """
+    Test contains filter on a string field.
+    """
+
+    schema = Schema(query=Query)
+
+    query = """
+    query {
+        events (tags_Contains: []) {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+    """
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data["events"]["edges"] == []

--- a/graphene_django/filter/tests/test_contains_filter.py
+++ b/graphene_django/filter/tests/test_contains_filter.py
@@ -6,7 +6,7 @@ from ...compat import ArrayField, MissingType
 
 
 @pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
-def test_string_contains_multiple(Event, Query):
+def test_string_contains_multiple(Query):
     """
     Test contains filter on a string field.
     """
@@ -32,7 +32,7 @@ def test_string_contains_multiple(Event, Query):
 
 
 @pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
-def test_string_contains_one(Event, Query):
+def test_string_contains_one(Query):
     """
     Test contains filter on a string field.
     """
@@ -59,7 +59,7 @@ def test_string_contains_one(Event, Query):
 
 
 @pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
-def test_string_contains_none(Event, Query):
+def test_string_contains_none(Query):
     """
     Test contains filter on a string field.
     """

--- a/graphene_django/filter/tests/test_overlap_filter.py
+++ b/graphene_django/filter/tests/test_overlap_filter.py
@@ -1,0 +1,84 @@
+import pytest
+
+from graphene import Schema
+
+from ...compat import ArrayField, MissingType
+
+
+@pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
+def test_string_overlap_multiple(Event, Query):
+    """
+    Test overlap filter on a string field.
+    """
+
+    schema = Schema(query=Query)
+
+    query = """
+    query {
+        events (tags_Overlap: ["concert", "music"]) {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+    """
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data["events"]["edges"] == [
+        {"node": {"name": "Live Show"}},
+        {"node": {"name": "Musical"}},
+        {"node": {"name": "Ballet"}},
+    ]
+
+
+@pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
+def test_string_overlap_one(Event, Query):
+    """
+    Test overlap filter on a string field.
+    """
+
+    schema = Schema(query=Query)
+
+    query = """
+    query {
+        events (tags_Overlap: ["music"]) {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+    """
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data["events"]["edges"] == [
+        {"node": {"name": "Live Show"}},
+        {"node": {"name": "Musical"}},
+    ]
+
+
+@pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
+def test_string_overlap_none(Event, Query):
+    """
+    Test overlap filter on a string field.
+    """
+
+    schema = Schema(query=Query)
+
+    query = """
+    query {
+        events (tags_Overlap: []) {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+    """
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data["events"]["edges"] == []

--- a/graphene_django/filter/tests/test_overlap_filter.py
+++ b/graphene_django/filter/tests/test_overlap_filter.py
@@ -6,7 +6,7 @@ from ...compat import ArrayField, MissingType
 
 
 @pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
-def test_string_overlap_multiple(Event, Query):
+def test_string_overlap_multiple(Query):
     """
     Test overlap filter on a string field.
     """
@@ -34,7 +34,7 @@ def test_string_overlap_multiple(Event, Query):
 
 
 @pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
-def test_string_overlap_one(Event, Query):
+def test_string_overlap_one(Query):
     """
     Test overlap filter on a string field.
     """
@@ -61,7 +61,7 @@ def test_string_overlap_one(Event, Query):
 
 
 @pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
-def test_string_overlap_none(Event, Query):
+def test_string_overlap_none(Query):
     """
     Test overlap filter on a string field.
     """

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -42,7 +42,7 @@ def get_filtering_args_from_filterset(filterset_class, type):
             field = convert_form_field(form_field)
 
         if filter_type in {"in", "range", "contains", "overlap"}:
-            # Replace CSV filters (`in`, `range`) argument type to be a list of
+            # Replace CSV filters (`in`, `range`, `contains`, `overlap`) argument type to be a list of
             # the same type as the field.  See comments in
             # `replace_csv_filters` method for more details.
             field = graphene.List(field.get_type())
@@ -71,7 +71,7 @@ def get_filterset_class(filterset_class, **meta):
 
 def replace_csv_filters(filterset_class):
     """
-    Replace the "in" and "range" filters (that are not explicitly declared) to not be BaseCSVFilter (BaseInFilter, BaseRangeFilter) objects anymore
+    Replace the "in", "contains", "overlap" and "range" filters (that are not explicitly declared) to not be BaseCSVFilter (BaseInFilter, BaseRangeFilter) objects anymore
     but regular Filter objects that simply use the input value as filter argument on the queryset.
 
     This is because those BaseCSVFilter are expecting a string as input with comma separated value but with GraphQl we

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -11,7 +11,7 @@ from py.test import raises
 import graphene
 from graphene.relay import Node
 
-from ..compat import JSONField, MissingType
+from ..compat import IntegerRangeField, MissingType
 from ..fields import DjangoConnectionField
 from ..types import DjangoObjectType
 from ..utils import DJANGO_FILTER_INSTALLED
@@ -113,7 +113,7 @@ def test_should_query_well():
     assert result.data == expected
 
 
-@pytest.mark.skipif(JSONField is MissingType, reason="RangeField should exist")
+@pytest.mark.skipif(IntegerRangeField is MissingType, reason="RangeField should exist")
 def test_should_query_postgres_fields():
     from django.contrib.postgres.fields import (
         IntegerRangeField,


### PR DESCRIPTION
This PR adds support for the [contains](https://docs.djangoproject.com/en/3.1/ref/contrib/postgres/fields/#contains) and [overlap](https://docs.djangoproject.com/en/3.1/ref/contrib/postgres/fields/#overlap) filters of Django.

This is basically extending https://github.com/graphql-python/graphene-django/pull/1070 (written by @tcleonard).

---

**Contains:**

```gql
query {
  # Returns Events that have `music` AND `sport` tags.
  events(tags_Contains: ["music", "sport"]) {
    edges {
      node {
        name
        tags
      }
    }
  }
}
```

**Overlap:**

```gql
query {
  # Returns Events that have `music` OR `sport` tags.
  events(tags_Overlap: ["music", "sport"]) {
    edges {
      node {
        name
        tags
      }
    }
  }
}
```

---

_Note: this also applies the project setup fix from https://github.com/graphql-python/graphene-django/pull/1087 to the `v2` branch._