### PR TITLE
Only override non declared filters 

### DIFF
--- a/graphene_django/filter/tests/test_in_filter.py
+++ b/graphene_django/filter/tests/test_in_filter.py
@@ -35,12 +35,13 @@ class PersonFilterSet(FilterSet):
         model = Person
         fields = {"name": ["in"]}
 
-    
+
 class PersonNode(DjangoObjectType):
     class Meta:
         model = Person
         interfaces = (Node,)
         filterset_class = PersonFilterSet
+
 
 class Query(ObjectType):
     pets = DjangoFilterConnectionField(PetNode)

--- a/graphene_django/filter/tests/test_in_filter.py
+++ b/graphene_django/filter/tests/test_in_filter.py
@@ -33,20 +33,14 @@ class PetNode(DjangoObjectType):
 class PersonFilterSet(FilterSet):
     class Meta:
         model = Person
-        fields = {}
+        fields = {"name": ["in"]}
 
-    names = filters.BaseInFilter(method="filter_names")
-
-    def filter_names(self, qs, name, value):
-        return qs.filter(name__in=value)
-
-
+    
 class PersonNode(DjangoObjectType):
     class Meta:
         model = Person
         interfaces = (Node,)
         filterset_class = PersonFilterSet
-
 
 class Query(ObjectType):
     pets = DjangoFilterConnectionField(PetNode)
@@ -92,7 +86,7 @@ def test_string_in_filter_with_filterset_class():
 
     query = """
     query {
-        people (names: ["John", "Michael"]) {
+        people (name_In: ["John", "Michael"]) {
             edges {
                 node {
                     name

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -79,23 +79,24 @@ def replace_csv_filters(filterset_class):
     """
     for name, filter_field in list(filterset_class.base_filters.items()):
         filter_type = filter_field.lookup_expr
-        if name not in filterset_class.declared_filters:
-            if filter_type in {"in", "contains", "overlap"}:
-                filterset_class.base_filters[name] = InFilter(
-                    field_name=filter_field.field_name,
-                    lookup_expr=filter_field.lookup_expr,
-                    label=filter_field.label,
-                    method=filter_field.method,
-                    exclude=filter_field.exclude,
-                    **filter_field.extra
-                )
+        if name in filterset_class.declared_filters:
+            continue
+        if filter_type in {"in", "contains", "overlap"}:
+            filterset_class.base_filters[name] = InFilter(
+                field_name=filter_field.field_name,
+                lookup_expr=filter_field.lookup_expr,
+                label=filter_field.label,
+                method=filter_field.method,
+                exclude=filter_field.exclude,
+                **filter_field.extra
+            )
 
-            elif filter_type == "range":
-                filterset_class.base_filters[name] = RangeFilter(
-                    field_name=filter_field.field_name,
-                    lookup_expr=filter_field.lookup_expr,
-                    label=filter_field.label,
-                    method=filter_field.method,
-                    exclude=filter_field.exclude,
-                    **filter_field.extra
-                )
+        elif filter_type == "range":
+            filterset_class.base_filters[name] = RangeFilter(
+                field_name=filter_field.field_name,
+                lookup_expr=filter_field.lookup_expr,
+                label=filter_field.label,
+                method=filter_field.method,
+                exclude=filter_field.exclude,
+                **filter_field.extra
+            )

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -79,22 +79,23 @@ def replace_csv_filters(filterset_class):
     """
     for name, filter_field in list(filterset_class.base_filters.items()):
         filter_type = filter_field.lookup_expr
-        if filter_type in {"in", "contains", "overlap"}:
-            filterset_class.base_filters[name] = InFilter(
-                field_name=filter_field.field_name,
-                lookup_expr=filter_field.lookup_expr,
-                label=filter_field.label,
-                method=filter_field.method,
-                exclude=filter_field.exclude,
-                **filter_field.extra
-            )
+        if name not in filterset_class.declared_filters:
+            if filter_type in {"in", "contains", "overlap"}:
+                filterset_class.base_filters[name] = InFilter(
+                    field_name=filter_field.field_name,
+                    lookup_expr=filter_field.lookup_expr,
+                    label=filter_field.label,
+                    method=filter_field.method,
+                    exclude=filter_field.exclude,
+                    **filter_field.extra
+                )
 
-        elif filter_type == "range":
-            filterset_class.base_filters[name] = RangeFilter(
-                field_name=filter_field.field_name,
-                lookup_expr=filter_field.lookup_expr,
-                label=filter_field.label,
-                method=filter_field.method,
-                exclude=filter_field.exclude,
-                **filter_field.extra
-            )
+            elif filter_type == "range":
+                filterset_class.base_filters[name] = RangeFilter(
+                    field_name=filter_field.field_name,
+                    lookup_expr=filter_field.lookup_expr,
+                    label=filter_field.label,
+                    method=filter_field.method,
+                    exclude=filter_field.exclude,
+                    **filter_field.extra
+                )


### PR DESCRIPTION
As the docstring of `replace_csv_filters` already states, declared filters should not be converted to InFilter/RangeFilter since it is possible that these are intentionally customised. This function is now actually also converting declared filters