### PR TITLE
Add ability to pass `execution_context_class` to `GraphQLView.as_view()`

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -85,7 +85,7 @@ class GraphQLView(View):
     batch = False
     subscription_path = None
     execution_context_class = None
-    
+
     def __init__(
         self,
         schema=None,

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -84,7 +84,8 @@ class GraphQLView(View):
     pretty = False
     batch = False
     subscription_path = None
-
+    execution_context_class = None
+    
     def __init__(
         self,
         schema=None,


### PR DESCRIPTION
Currently when passing `execution_context_class` like this:

```
GraphQLView.as_view(execution_context_class=CustomContext)
```

you get the following error from `View.as_view()`
```
TypeError: GraphQLView() received an invalid keyword 'execution_context_class'. as_view only accepts arguments that are already attributes of the class.
```

this PR fixes the `hasattr` check in `.as_view`.

Fixes: #1072