### PR TITLE
Doc clarification for headers arg in testing utils

### DIFF
--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -28,7 +28,9 @@ def graphql_query(
         variables (dict)            - If provided, the "variables" field in GraphQL will be
                                       set to this value.
         headers (dict)              - If provided, the headers in POST request to GRAPHQL_URL
-                                      will be set to this value.
+                                      will be set to this value. Keys should be prepended with
+                                      "HTTP_" (e.g. to specify the "Authorization" HTTP header,
+                                      use "HTTP_AUTHORIZATION" as the key).
         client (django.test.Client) - Test client. Defaults to django.test.Client.
         graphql_url (string)        - URL to graphql endpoint. Defaults to "/graphql".
 
@@ -85,7 +87,9 @@ class GraphQLTestCase(TestCase):
             variables (dict)  - If provided, the "variables" field in GraphQL will be
                                 set to this value.
             headers (dict)    - If provided, the headers in POST request to GRAPHQL_URL
-                                will be set to this value.
+                                will be set to this value. Keys should be prepended with
+                                "HTTP_" (e.g. to specify the "Authorization" HTTP header,
+                                use "HTTP_AUTHORIZATION" as the key).       
 
         Returns:
             Response object from client


### PR DESCRIPTION
I think it might be helpful to add an explicit hint that HTTP headers should be prepended with `HTTP_` as required by `django.test.Client` (at least it was not super obvious to me when I tried to use it).