### PR TITLE
enhancement: DjangoDebugContext captures exceptions

### DIFF
--- a/docs/debug.rst
+++ b/docs/debug.rst
@@ -4,7 +4,7 @@ Django Debug Middleware
 You can debug your GraphQL queries in a similar way to
 `django-debug-toolbar <https://django-debug-toolbar.readthedocs.org/>`__,
 but outputting in the results in GraphQL response as fields, instead of
-the graphical HTML interface.
+the graphical HTML interface. Exceptions with their stack traces are also exposed.
 
 For that, you will need to add the plugin in your graphene schema.
 
@@ -62,6 +62,10 @@ the GraphQL request, like:
       _debug {
         sql {
           rawSql
+        }
+        exceptions {
+          message
+          stack
         }
       }
     }

--- a/graphene_django/debug/exception/formating.py
+++ b/graphene_django/debug/exception/formating.py
@@ -1,0 +1,17 @@
+import traceback
+
+from django.utils.encoding import force_str
+
+from .types import DjangoDebugException
+
+
+def wrap_exception(exception):
+    return DjangoDebugException(
+        message=force_str(exception),
+        exc_type=force_str(type(exception)),
+        stack="".join(
+            traceback.format_exception(
+                etype=type(exception), value=exception, tb=exception.__traceback__
+            )
+        ),
+    )

--- a/graphene_django/debug/exception/types.py
+++ b/graphene_django/debug/exception/types.py
@@ -1,0 +1,10 @@
+from graphene import ObjectType, String
+
+
+class DjangoDebugException(ObjectType):
+    class Meta:
+        description = "Represents a single exception raised."
+
+    exc_type = String(required=True, description="The class of the exception")
+    message = String(required=True, description="The message of the exception")
+    stack = String(required=True, description="The stack trace")

--- a/graphene_django/debug/middleware.py
+++ b/graphene_django/debug/middleware.py
@@ -3,6 +3,7 @@ from django.db import connections
 from promise import Promise
 
 from .sql.tracking import unwrap_cursor, wrap_cursor
+from .exception.formating import wrap_exception
 from .types import DjangoDebug
 
 
@@ -10,14 +11,19 @@ class DjangoDebugContext(object):
     def __init__(self):
         self.debug_promise = None
         self.promises = []
+        self.object = DjangoDebug(sql=[], exceptions=[])
         self.enable_instrumentation()
-        self.object = DjangoDebug(sql=[])
 
     def get_debug_promise(self):
         if not self.debug_promise:
             self.debug_promise = Promise.all(self.promises)
             self.promises = []
         return self.debug_promise.then(self.on_resolve_all_promises).get()
+
+    def on_resolve_error(self, value):
+        if hasattr(self, "object"):
+            self.object.exceptions.append(wrap_exception(value))
+        return Promise.reject(value)
 
     def on_resolve_all_promises(self, values):
         if self.promises:
@@ -57,6 +63,9 @@ class DjangoDebugMiddleware(object):
                 )
         if info.schema.get_type("DjangoDebug") == info.return_type:
             return context.django_debug.get_debug_promise()
-        promise = next(root, info, **args)
+        try:
+            promise = next(root, info, **args)
+        except Exception as e:
+            return context.django_debug.on_resolve_error(e)
         context.django_debug.add_promise(promise)
         return promise

--- a/graphene_django/debug/types.py
+++ b/graphene_django/debug/types.py
@@ -1,6 +1,7 @@
 from graphene import List, ObjectType
 
 from .sql.types import DjangoDebugSQL
+from .exception.types import DjangoDebugException
 
 
 class DjangoDebug(ObjectType):
@@ -8,3 +9,6 @@ class DjangoDebug(ObjectType):
         description = "Debugging information for the current query."
 
     sql = List(DjangoDebugSQL, description="Executed SQL queries for this API query.")
+    exceptions = List(
+        DjangoDebugException, description="Raise exceptions for this API query."
+    )


### PR DESCRIPTION
DjangoDebugContext captures exceptions and allows captured stack traces to be queried. Example usage added to documentation. 

Fixes #1121

Discovered that `next` does not return a promise in our test environment. Do I need to check if the return is a promise?