### PR TITLE
Fix schema dump on windows

### DIFF
--- a/graphene_django/management/commands/graphql_schema.py
+++ b/graphene_django/management/commands/graphql_schema.py
@@ -55,7 +55,7 @@ class Command(CommandArguments):
             json.dump(schema_dict, outfile, indent=indent, sort_keys=True)
 
     def save_graphql_file(self, out, schema):
-        with open(out, "w") as outfile:
+        with open(out, "w", encoding="utf-8") as outfile:
             outfile.write(print_schema(schema.graphql_schema))
 
     def get_schema(self, schema, out, indent):


### PR DESCRIPTION
Without explicitly setting the encoding to "utf-8" I get the following error on windows (python 3.9)

```
  File "D:\env\lib\site-packages\graphene_django\management\commands\graphql_schema.py", line 115, in handle
    self.get_schema(schema, out, indent)
  File "D:\env\lib\site-packages\graphene_django\management\commands\graphql_schema.py", line 72, in get_schema
    self.save_graphql_file(out, schema)                                                                                   
  File "D:\env\lib\site-packages\graphene_django\management\commands\graphql_schema.py", line 59, in save_graphql_file      
    outfile.write(print_schema(schema.graphql_schema))                                                                    
  File "C:\Users\u\AppData\Local\Programs\Python\Python39\lib\encodings\cp1252.py", line 19, in encode 
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
```