### PR TITLE
Fix subscriptions in JS

### DIFF
--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -123,8 +123,8 @@
     if (operationType === "subscription") {
       return {
         subscribe: function (observer) {
-          subscriptionClient.request(graphQLParams).subscribe(observer);
           activeSubscription = subscriptionClient;
+          return subscriptionClient.request(graphQLParams, opts).subscribe(observer);
         },
       };
     } else {


### PR DESCRIPTION
The "play" button on the graphiql web page does not work as expected with subscription.
With the following fix, when launching a subscription the "play" button changes to a "stop" button, allowing to stop subscriptions properly.
See the following video capture which shows how the fix works:
https://youtu.be/2Aks6wnYeRc

Fixes https://github.com/graphql-python/graphene-django/issues/1125