### PR TITLE
Fix: Allow add external resolver

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -61,12 +61,13 @@ class DjangoListField(Field):
         return queryset
 
     def wrap_resolve(self, parent_resolver):
+        resolver = super(DjangoListField, self).wrap_resolve(parent_resolver)
         _type = self.type
         if isinstance(_type, NonNull):
             _type = _type.of_type
         django_object_type = _type.of_type.of_type
         return partial(
-            self.list_resolver, django_object_type, parent_resolver, self.get_manager(),
+            self.list_resolver, django_object_type, resolver, self.get_manager(),
         )
 
 


### PR DESCRIPTION
Currently you cannot use an external resolver in `DjangoListField`. If you pass a resolver as a parameter in the Field definition it is ignored completely. This PR allows to pass the the resolver as an argument in the Field definition.

Example:

```python
def external_resolver(parent, info, **args):
    return ...

class Query(graphene.ObjectType):
    all_xxx = DjangoListField(XXXType, resolver=external_resolver)
```