### PR TITLE
Fix main branch tests failing due to wrong instancing of Missing class

### DIFF
--- a/graphene_django/compat.py
+++ b/graphene_django/compat.py
@@ -1,5 +1,6 @@
 class MissingType(object):
-    pass
+    def __init__(self, *args, **kwargs):
+        pass
 
 
 try:

--- a/graphene_django/filter/tests/test_array_field_exact_filter.py
+++ b/graphene_django/filter/tests/test_array_field_exact_filter.py
@@ -81,6 +81,7 @@ def test_array_field_exact_empty_list(Query):
     ]
 
 
+@pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
 def test_array_field_filter_schema_type(Query):
     """
     Check that the type in the filter is an array field like on the object type.


### PR DESCRIPTION
Main tests are broken in the main branch because the MissingType does not take any arguments.