### PR TITLE
Fix broken `form.save()` call in `DjangoFormMutation.perform_mutate`

### DIFF
--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -101,7 +101,10 @@ class DjangoFormMutation(BaseDjangoFormMutation):
 
     @classmethod
     def perform_mutate(cls, form, info):
-        form.save()
+        if hasattr(form, "save"):
+            # `save` method won't exist on plain Django forms, but this mutation can
+            # in theory be used with `ModelForm`s as well and we do want to save them.
+            form.save()
         return cls(errors=[], **form.cleaned_data)
 
 


### PR DESCRIPTION
Django's plain (non-model) forms don't have the `save` method, so
calling this would just result in an `AttributeError` before this
change.

Resolves #1152

---

Didn't want to just remove the `form.save()` line completely, since the tests at least "document" it as a valid usage to pass a `ModelForm` as the `form_class` of a plain `DjangoFormMutation`:

https://github.com/graphql-python/graphene-django/blob/80ea51fc3b433430efc000cbd6b126215ab53905/graphene_django/tests/mutations.py#L9-L11

(`PetForm` is a `forms.ModelForm` here)