### PR TITLE
Add support to persist GraphQL headers in GraphiQL

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -207,3 +207,22 @@ Default: ``True``
    GRAPHENE = {
       'GRAPHIQL_HEADER_EDITOR_ENABLED': True,
    }
+
+
+``GRAPHIQL_SHOULD_PERSIST_HEADERS``
+---------------------
+
+Set to ``True`` if you want to persist GraphiQL headers after refreshing the page.
+
+This setting is passed to ``shouldPersistHeaders`` GraphiQL options, for details refer to GraphiQLDocs_.
+
+.. _GraphiQLDocs: https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
+
+
+Default: ``False``
+
+.. code:: python
+
+   GRAPHENE = {
+      'GRAPHIQL_SHOULD_PERSIST_HEADERS': False,
+   }

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -41,6 +41,7 @@ DEFAULTS = {
     # This sets headerEditorEnabled GraphiQL option, for details go to
     # https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
     "GRAPHIQL_HEADER_EDITOR_ENABLED": True,
+    "GRAPHIQL_SHOULD_PERSIST_HEADERS": False,
     "ATOMIC_MUTATIONS": False,
 }
 

--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -176,6 +176,7 @@
     onEditVariables: onEditVariables,
     onEditOperationName: onEditOperationName,
     headerEditorEnabled: GRAPHENE_SETTINGS.graphiqlHeaderEditorEnabled,
+    shouldPersistHeaders: GRAPHENE_SETTINGS.graphiqlShouldPersistHeaders,
     query: parameters.query,
   };
   if (parameters.variables) {

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -46,6 +46,7 @@ add "&raw" to the end of the URL within a browser.
       subscriptionPath: "{{subscription_path}}",
     {% endif %}
       graphiqlHeaderEditorEnabled: {{ graphiql_header_editor_enabled|yesno:"true,false" }},
+      graphiqlShouldPersistHeaders: {{ graphiql_should_persist_headers|yesno:"true,false" }},
     };
   </script>
   <script src="{% static 'graphene_django/graphiql.js' %}"></script>

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -163,6 +163,7 @@ class GraphQLView(View):
                     subscription_path=self.subscription_path,
                     # GraphiQL headers tab,
                     graphiql_header_editor_enabled=graphene_settings.GRAPHIQL_HEADER_EDITOR_ENABLED,
+                    graphiql_should_persist_headers=graphene_settings.GRAPHIQL_SHOULD_PERSIST_HEADERS,
                 )
 
             if self.batch:


### PR DESCRIPTION
This PR allows you to set `shouldPersistHeaders` GraphiQL option via Graphene setting: `GRAPHIQL_SHOULD_PERSIST_HEADERS`.