### PR TITLE
Add missing auto fields

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -175,10 +175,8 @@ def convert_field_to_id(field, registry=None):
 if hasattr(models, "SmallAutoField"):
 
     @convert_django_field.register(models.SmallAutoField)
-    def convert_field_to_id(field, registry=None):
-        return ID(
-            description=get_django_field_description(field), required=not field.null
-        )
+    def convert_field_small_to_id(field, registry=None):
+        return convert_field_to_id(field, registry)
 
 
 @convert_django_field.register(models.UUIDField)

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -166,8 +166,8 @@ def convert_field_to_string(field, registry=None):
     )
 
 
+#@convert_django_field.register(models.SmallAutoField)
 @convert_django_field.register(models.BigAutoField)
-@convert_django_field.register(models.SmallAutoField)
 @convert_django_field.register(models.AutoField)
 def convert_field_to_id(field, registry=None):
     return ID(description=get_django_field_description(field), required=not field.null)

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -166,6 +166,8 @@ def convert_field_to_string(field, registry=None):
     )
 
 
+@convert_django_field.register(models.BigAutoField)
+@convert_django_field.register(models.SmallAutoField)
 @convert_django_field.register(models.AutoField)
 def convert_field_to_id(field, registry=None):
     return ID(description=get_django_field_description(field), required=not field.null)

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -166,11 +166,19 @@ def convert_field_to_string(field, registry=None):
     )
 
 
-#@convert_django_field.register(models.SmallAutoField)
 @convert_django_field.register(models.BigAutoField)
 @convert_django_field.register(models.AutoField)
 def convert_field_to_id(field, registry=None):
     return ID(description=get_django_field_description(field), required=not field.null)
+
+
+if hasattr(models, "SmallAutoField"):
+
+    @convert_django_field.register(models.SmallAutoField)
+    def convert_field_to_id(field, registry=None):
+        return ID(
+            description=get_django_field_description(field), required=not field.null
+        )
 
 
 @convert_django_field.register(models.UUIDField)

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -111,6 +111,14 @@ def test_should_auto_convert_id():
     assert_conversion(models.AutoField, graphene.ID, primary_key=True)
 
 
+def test_should_big_auto_convert_id():
+    assert_conversion(models.BigAutoField, graphene.ID, primary_key=True)
+
+
+def test_should_small_auto_convert_id():
+    assert_conversion(models.SmallAutoField, graphene.ID, primary_key=True)
+
+
 def test_should_uuid_convert_id():
     assert_conversion(models.UUIDField, graphene.UUID)
 

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -116,7 +116,8 @@ def test_should_big_auto_convert_id():
 
 
 def test_should_small_auto_convert_id():
-    assert_conversion(models.SmallAutoField, graphene.ID, primary_key=True)
+    if hasattr(models, 'SmallAutoField'):
+        assert_conversion(models.SmallAutoField, graphene.ID, primary_key=True)
 
 
 def test_should_uuid_convert_id():

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -116,7 +116,7 @@ def test_should_big_auto_convert_id():
 
 
 def test_should_small_auto_convert_id():
-    if hasattr(models, 'SmallAutoField'):
+    if hasattr(models, "SmallAutoField"):
         assert_conversion(models.SmallAutoField, graphene.ID, primary_key=True)
 
 


### PR DESCRIPTION
`BigAutoField` and `SmallAutoField` have been in Django for a while and were missing as IDs.  `BigAutoField` is the new default upcoming so it would be good to get the support in now.