### PR TITLE
Fixed Django >= 3.2 issue

### DIFF
--- a/docs/tutorial-plain.rst
+++ b/docs/tutorial-plain.rst
@@ -77,6 +77,19 @@ Add ingredients as INSTALLED_APPS:
         "cookbook.ingredients",
     ]
 
+Ensure Django >= 3.2 automatic AppConfig discovery works by adding ``cookbook.`` prefix to ``name = 'ingredients'`` config:
+
+.. code:: python
+
+    # cookbook/apps.py
+
+    from django.apps import AppConfig
+
+
+    class IngredientsConfig(AppConfig):
+        default_auto_field = 'django.db.models.BigAutoField'
+        name = 'cookbook.ingredients'
+
 
 Don't forget to create & run migrations:
 


### PR DESCRIPTION
I faced this issue while doing the Basic Tutorial

```
(env) hauke@haukes-ubuntu:~/Python/Zucker$ python manage.py migrate
Traceback (most recent call last):
  File "/home/hauke/Python/Zucker/env/lib/python3.8/site-packages/django/apps/config.py", line 244, in create
    app_module = import_module(app_name)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'ingredients'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "manage.py", line 22, in <module>
    main()
  File "manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/home/hauke/Python/Zucker/env/lib/python3.8/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/home/hauke/Python/Zucker/env/lib/python3.8/site-packages/django/core/management/__init__.py", line 395, in execute
    django.setup()
  File "/home/hauke/Python/Zucker/env/lib/python3.8/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/hauke/Python/Zucker/env/lib/python3.8/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "/home/hauke/Python/Zucker/env/lib/python3.8/site-packages/django/apps/config.py", line 246, in create
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Cannot import 'ingredients'. Check that 'cookbook.ingredients.apps.IngredientsConfig.name' is correct.
```