### PR TITLE
Make instructions runnable without tweaking

### DIFF
--- a/docs/tutorial-plain.rst
+++ b/docs/tutorial-plain.rst
@@ -35,6 +35,7 @@ Now sync your database for the first time:
 
 .. code:: bash
 
+    cd ..
     python manage.py migrate
 
 Let's create a few simple models...
@@ -77,6 +78,18 @@ Add ingredients as INSTALLED_APPS:
         "cookbook.ingredients",
     ]
 
+Make sure the app name in ``cookbook.ingredients.apps.IngredientsConfig`` is set to ``cookbook.ingredients``.
+
+.. code:: python
+
+    # cookbook/ingredients/apps.py
+
+    from django.apps import AppConfig
+    
+    
+    class IngredientsConfig(AppConfig):
+        default_auto_field = 'django.db.models.BigAutoField'
+        name = 'cookbook.ingredients'
 
 Don't forget to create & run migrations:
 


### PR DESCRIPTION
Introduces two changes to make sure the instructions in the tutorial don't require debugging:

- Add `cd ..` when first syncing the database so that `manage.py` is accessible in the working directory.
- Change `cookbook.ingredients.apps.IngredientsConfig.name` to `cookbook.ingredients` from `ingredients` to prevent the following exception:

```python
django.core.exceptions.ImproperlyConfigured: Cannot import 'ingredients'. Check that 'cookbook.ingredients.apps.IngredientsConfig.name' is correct.
```