### PR TITLE
queryset.count() optimized

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -1,6 +1,7 @@
 from functools import partial
 
 from django.db.models.query import QuerySet
+from django.db.models import Count
 from graphql_relay.connection.arrayconnection import (
     connection_from_array_slice,
     cursor_to_offset,
@@ -144,7 +145,7 @@ class DjangoConnectionField(ConnectionField):
         iterable = maybe_queryset(iterable)
 
         if isinstance(iterable, QuerySet):
-            list_length = iterable.count()
+            list_length = iterable.aggregate(Count('pk'))['pk__count']
         else:
             list_length = len(iterable)
         list_slice_length = (


### PR DESCRIPTION
Sorry this is my first time contributing to open source, 

In this PR, I have made the changes related to how count of queryset is evaluated.
SO currently, what we do is :
**list_length = iterable.count()**
This leads to a SQL query of the form : SELECT COUNT(*) as __count which is time consuming at SQL level because it does a count on the all records,

Solution:
Since we are only interested in the queryset count or number of records for pagination purposes, I feel the optimized or faster way to do this would be to run a SQL Query like : SELECT COUNT('pk') as pk__count where pk refers to the primary key in the db table. This query would definitely consume lesser time than SELECT COUNT(*) as it will do a count on primary key.
TO do that we can change the line of code from 
**list_length = iterable.count()**
TO :
**list_length = iterable.aggregate(Count('pk'))['pk__count']** // this will run a query like SELECT COUNT('pk') as pk__count

I feel this change can bring some speedup in graphql queries as we are now only fetching count of primary key rather than count(*) which can give some speed advantages.

Please correct me if I am wrong. Thanks :) 