### PR TITLE
Update using `client_mutation_id` for SerializerMutation 

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -166,9 +166,17 @@ def convert_field_to_string(field, registry=None):
     )
 
 
+@convert_django_field.register(models.BigAutoField)
 @convert_django_field.register(models.AutoField)
 def convert_field_to_id(field, registry=None):
     return ID(description=get_django_field_description(field), required=not field.null)
+
+
+if hasattr(models, "SmallAutoField"):
+
+    @convert_django_field.register(models.SmallAutoField)
+    def convert_field_small_to_id(field, registry=None):
+        return convert_field_to_id(field, registry)
 
 
 @convert_django_field.register(models.UUIDField)

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -111,6 +111,15 @@ def test_should_auto_convert_id():
     assert_conversion(models.AutoField, graphene.ID, primary_key=True)
 
 
+def test_should_big_auto_convert_id():
+    assert_conversion(models.BigAutoField, graphene.ID, primary_key=True)
+
+
+def test_should_small_auto_convert_id():
+    if hasattr(models, "SmallAutoField"):
+        assert_conversion(models.SmallAutoField, graphene.ID, primary_key=True)
+
+
 def test_should_uuid_convert_id():
     assert_conversion(models.UUIDField, graphene.UUID)
 

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -58,23 +58,23 @@ class GraphQLView(View):
     graphiql_template = "graphene/graphiql.html"
 
     # Polyfill for window.fetch.
-    whatwg_fetch_version = "3.2.0"
-    whatwg_fetch_sri = "sha256-l6HCB9TT2v89oWbDdo2Z3j+PSVypKNLA/nqfzSbM8mo="
+    whatwg_fetch_version = "3.6.2"
+    whatwg_fetch_sri = "sha256-+pQdxwAcHJdQ3e/9S4RK6g8ZkwdMgFQuHvLuN5uyk5c="
 
     # React and ReactDOM.
-    react_version = "16.13.1"
-    react_sri = "sha256-yUhvEmYVhZ/GGshIQKArLvySDSh6cdmdcIx0spR3UP4="
-    react_dom_sri = "sha256-vFt3l+illeNlwThbDUdoPTqF81M8WNSZZZt3HEjsbSU="
+    react_version = "17.0.2"
+    react_sri = "sha256-Ipu/TQ50iCCVZBUsZyNJfxrDk0E2yhaEIz0vqI+kFG8="
+    react_dom_sri = "sha256-nbMykgB6tsOFJ7OdVmPpdqMFVk4ZsqWocT6issAPUF0="
 
     # The GraphiQL React app.
-    graphiql_version = "1.0.3"
-    graphiql_sri = "sha256-VR4buIDY9ZXSyCNFHFNik6uSe0MhigCzgN4u7moCOTk="
-    graphiql_css_sri = "sha256-LwqxjyZgqXDYbpxQJ5zLQeNcf7WVNSJ+r8yp2rnWE/E="
+    graphiql_version = "1.4.1"  # "1.0.3"
+    graphiql_sri = "sha256-JUMkXBQWZMfJ7fGEsTXalxVA10lzKOS9loXdLjwZKi4="  # "sha256-VR4buIDY9ZXSyCNFHFNik6uSe0MhigCzgN4u7moCOTk="
+    graphiql_css_sri = "sha256-Md3vdR7PDzWyo/aGfsFVF4tvS5/eAUWuIsg9QHUusCY="  # "sha256-LwqxjyZgqXDYbpxQJ5zLQeNcf7WVNSJ+r8yp2rnWE/E="
 
     # The websocket transport library for subscriptions.
-    subscriptions_transport_ws_version = "0.9.17"
+    subscriptions_transport_ws_version = "0.9.18"
     subscriptions_transport_ws_sri = (
-        "sha256-kCDzver8iRaIQ/SVlfrIwxaBQ/avXf9GQFJRLlErBnk="
+        "sha256-i0hAXd4PdJ/cHX3/8tIy/Q/qKiWr5WSTxMFuL9tACkw="
     )
 
     schema = None


### PR DESCRIPTION
When using relay, it overrides the id of the model and provides a global id.  This id is often what is available when making queries. 
However, it is unusable to update the model object.
This seeks to make the `client_mutation_id` usable for updating the SerializerMutation