### PR TITLE
Cast translated description for DecimalField

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -205,7 +205,9 @@ def convert_field_to_boolean(field, registry=None):
 
 @convert_django_field.register(models.DecimalField)
 def convert_field_to_decimal(field, registry=None):
-    return Decimal(description=get_django_field_description(field), required=not field.null)
+    return Decimal(
+        description=get_django_field_description(field), required=not field.null
+    )
 
 
 @convert_django_field.register(models.FloatField)

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -205,7 +205,7 @@ def convert_field_to_boolean(field, registry=None):
 
 @convert_django_field.register(models.DecimalField)
 def convert_field_to_decimal(field, registry=None):
-    return Decimal(description=field.help_text, required=not field.null)
+    return Decimal(description=get_django_field_description(field), required=not field.null)
 
 
 @convert_django_field.register(models.FloatField)


### PR DESCRIPTION
https://github.com/graphql-python/graphene-django/pull/976 casts all the description fields to strings to prevent schema printing from failing whenever the description is a lazy translated string. The `DecimalField` however got in after the v3 merge and it currently misses the cast.