### PR TITLE
Fix code examples in queries.rst

### DIFF
--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -418,29 +418,29 @@ the core graphene pages for more information on customizing the Relay experience
 You can now execute queries like:
 
 
-.. code:: python
+.. code:: graphql
 
     {
         questions (first: 2, after: "YXJyYXljb25uZWN0aW9uOjEwNQ==") {
             pageInfo {
-            startCursor
-            endCursor
-            hasNextPage
-            hasPreviousPage
+                startCursor
+                endCursor
+                hasNextPage
+                hasPreviousPage
             }
             edges {
-            cursor
-            node {
-                id
-                question_text
-            }
+                cursor
+                node {
+                    id
+                    question_text
+                }
             }
         }
     }
 
 Which returns:
 
-.. code:: python
+.. code:: json
 
     {
         "data": {

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -151,7 +151,7 @@ For example the following ``Model`` and ``DjangoObjectType``:
 
 Results in the following GraphQL schema definition:
 
-.. code::
+.. code:: graphql
 
    type Pet {
      id: ID!
@@ -178,7 +178,7 @@ You can disable this automatic conversion by setting
             fields = ("id", "kind",)
             convert_choices_to_enum = False
 
-.. code::
+.. code:: graphql
 
   type Pet {
     id: ID!

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -313,7 +313,7 @@ Additionally, Resolvers will receive **any arguments declared in the field defin
             bar=graphene.Int()
         )
 
-        def resolve_question(root, info, foo, bar):
+        def resolve_question(root, info, foo=None, bar=None):
             # If `foo` or `bar` are declared in the GraphQL query they will be here, else None.
             return Question.objects.filter(foo=foo, bar=bar).first()
 
@@ -336,12 +336,12 @@ of Django's ``HTTPRequest`` in your resolve methods, such as checking for authen
     class Query(graphene.ObjectType):
         questions = graphene.List(QuestionType)
 
-    def resolve_questions(root, info):
-        # See if a user is authenticated
-        if info.context.user.is_authenticated():
-            return Question.objects.all()
-        else:
-            return Question.objects.none()
+        def resolve_questions(root, info):
+            # See if a user is authenticated
+            if info.context.user.is_authenticated():
+                return Question.objects.all()
+            else:
+                return Question.objects.none()
 
 
 DjangoObjectTypes


### PR DESCRIPTION
Code example in Arguments section doesn't work as stated in its comment — if "foo" or "bar" are not declare in the graphql query, it will be an error, not they become None.

Code example in Info section has invalid indentation, `resolve_questions()` seems to be a `Query` method, but it's indented as module-level function.