### PR TITLE
Fix ManyToMany field default filter type

### DIFF
--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -86,8 +86,11 @@ def get_filtering_args_from_filterset(filterset_class, type):
                 form_field = form_field or filter_field.field
                 field_type = convert_form_field(form_field).get_type()
 
-            if isinstance(filter_field, ListFilter) or isinstance(
-                filter_field, RangeFilter
+            if (
+                isinstance(filter_field, ListFilter)
+                or isinstance(filter_field, RangeFilter)
+                or isinstance(form_field, forms.ModelMultipleChoiceField)
+                or isinstance(form_field, GlobalIDMultipleChoiceField)
             ):
                 # Replace InFilter/RangeFilter filters (`in`, `range`) argument type to be a list of
                 # the same type as the field. See comments in `replace_csv_filters` method for more details.


### PR DESCRIPTION
It's a bug introduced in this commit: https://github.com/weilu/graphene-django/commit/2d4ca0ac7b60413a7c5d9a5a995ad478c05d6352 (part of PR #1119) It manifests as not accepting a list of IDs `[ID]` but rather a single ID `ID` as filtering arguments for a m2m field. The bug can be replicated by adding a many-to-many relationship in the cookbook example app. Happy to clean up what I have locally and push it to a branch for quick reference if necessary. 

I do want to add test cases to this PR but I thought it's best/fastest to have @zbyte64 or @tcleonard point me to where's the best place to add it as they are more familiar with the existing fixtures & setup. Happy to add on.

Also, side question to @tcleonard on his modification of the function `get_filtering_args_from_filterset` in the above-mentioned commit, why adding all the type checking branching code in this method itself rather than expanding/modifying `model_field.formfield` as based on my quick read that seems to be where the logic of translating model_field to form_field is intended to live?