### PR TITLE
Delay assignment of csrftoken in Graphiql

### DIFF
--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -10,14 +10,6 @@
   history,
   location,
 ) {
-  // Parse the cookie value for a CSRF token
-  var csrftoken;
-  var cookies = ("; " + document.cookie).split("; csrftoken=");
-  if (cookies.length == 2) {
-    csrftoken = cookies.pop().split(";").shift();
-  } else {
-    csrftoken = document.querySelector("[name=csrfmiddlewaretoken]").value;
-  }
 
   // Collect the URL parameters
   var parameters = {};
@@ -68,9 +60,19 @@
     var headers = opts.headers || {};
     headers['Accept'] = headers['Accept'] || 'application/json';
     headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+
+    // Parse the cookie value for a CSRF token
+    var csrftoken;
+    var cookies = ("; " + document.cookie).split("; csrftoken=");
+    if (cookies.length == 2) {
+      csrftoken = cookies.pop().split(";").shift();
+    } else {
+      csrftoken = document.querySelector("[name=csrfmiddlewaretoken]").value;
+    }
     if (csrftoken) {
       headers['X-CSRFToken'] = csrftoken
     }
+
     return fetch(fetchURL, {
       method: "post",
       headers: headers,


### PR DESCRIPTION
The `csrftoken` is currently assigned only when `graphiql.js` is first loaded. 

The current `csrftoken` can rotated by Django, for instance when a user logs in. [rotate_token](https://github.com/django/django/blob/3ff7f6cf07a722635d690785c31ac89484134bee/django/middleware/csrf.py#L118) performs the rotation.

When this happens, the `csrftoken` held by `graphiql.js` is invalid and Graphiql will receive CSRF errors.

This PR delays the assignment of the `csrftoken` by moving it into the `httpClient` function so when the `csrftoken` is rotated by Django, Graphiql can pick up the new token from the cookies.