### PR TITLE
Update requirements to the official graphene 3.0 release

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -1,12 +1,14 @@
 from functools import partial
 
 from django.db.models.query import QuerySet
-from graphql_relay.connection.arrayconnection import (
+
+from graphql_relay.connection.array_connection import (
     connection_from_array_slice,
     cursor_to_offset,
     get_offset_with_default,
     offset_to_cursor,
 )
+
 from promise import Promise
 
 from graphene import Int, NonNull

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,9 @@ setup(
     keywords="api graphql protocol rest relay graphene",
     packages=find_packages(exclude=["tests", "examples", "examples.*"]),
     install_requires=[
-        "graphene>=3.0.0b5,<4",
+        "graphene>=3.0,<4",
         "graphql-core>=3.1.0,<4",
+        "graphql-relay>=3.1.1,<4",
         "Django>=2.2",
         "promise>=2.1",
         "text-unidecode",


### PR DESCRIPTION
Also, Graphql-relay introduces breaking changes to this repo in version 3.1.1, so I used stricter pinning of the graphene and graphql-relay requirements and switching to `arrray_connection` in support of this upgrade; graphene 3.0 supports 3.0-4.0 which is too broad for graphene-django. 