### PR TITLE
STALEBOT: Update to stale out issues after one year

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: false
+daysUntilStale: 365
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: false
+daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
@@ -13,10 +13,9 @@ exemptLabels:
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: false
-# markComment: >
-  # This issue has been automatically marked as stale because it has not had
-  # recent activity. It will be closed if no further activity occurs. Thank you
-  # for your contributions.
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
In order to better triage issues, it would be helpful to clear out old issues. I used 365 as it seems to be the commonly used configuration for other open-source projects. Example: https://github.com/integrations/slack/blob/master/.github/stale.yml