### PR TITLE
minor fix on schema.py part

### DIFF
--- a/docs/tutorial-relay.rst
+++ b/docs/tutorial-relay.rst
@@ -151,7 +151,7 @@ Create ``cookbook/ingredients/schema.py`` and type the following:
             interfaces = (relay.Node, )
 
 
-    class Query(graphene.ObjectType):
+    class Query(ObjectType):
         category = relay.Node.Field(CategoryNode)
         all_categories = DjangoFilterConnectionField(CategoryNode)
 


### PR DESCRIPTION
The documentation already suggests importing ObjectType from graphene, graphene.ObjectType is not necessary while defining the Query class.