### PR TITLE
Fix documentation references: op_name -> operation_name

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -27,7 +27,7 @@ Usage:
                     }
                 }
                 ''',
-                op_name='myModel'
+                operation_name='myModel'
             )
 
             content = json.loads(response.content)
@@ -48,7 +48,7 @@ Usage:
                     }
                 }
                 ''',
-                op_name='myModel',
+                operation_name='myModel',
                 variables={'id': 1}
             )
 
@@ -72,7 +72,7 @@ Usage:
                     }
                 }
                 ''',
-                op_name='myMutation',
+                operation_name='myMutation',
                 input_data={'my_field': 'foo', 'other_field': 'bar'}
             )
 
@@ -107,7 +107,7 @@ Usage:
                     }
                 }
                 ''',
-                op_name='myMutation',
+                operation_name='myMutation',
                 input_data={'my_field': 'foo', 'other_field': 'bar'}
             )
 
@@ -147,7 +147,7 @@ To use pytest define a simple fixture using the query helper below
                     }
                 }
                 ''',
-                op_name='myModel'
+                operation_name='myModel'
             )
 
             content = json.loads(response.content)

--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -19,7 +19,7 @@ def graphql_query(
     Args:
         query (string)              - GraphQL query to run
         operation_name (string)     - If the query is a mutation or named query, you must
-                                      supply the op_name.  For annon queries ("{ ... }"),
+                                      supply the operation_name.  For annon queries ("{ ... }"),
                                       should be None (default).
         input_data (dict)           - If provided, the $input variable in GraphQL will be set
                                       to this value. If both ``input_data`` and ``variables``,
@@ -78,7 +78,7 @@ class GraphQLTestMixin(object):
         Args:
             query (string)    - GraphQL query to run
             operation_name (string)  - If the query is a mutation or named query, you must
-                                supply the op_name.  For annon queries ("{ ... }"),
+                                supply the operation_name.  For annon queries ("{ ... }"),
                                 should be None (default).
             input_data (dict) - If provided, the $input variable in GraphQL will be set
                                 to this value. If both ``input_data`` and ``variables``,
@@ -89,7 +89,7 @@ class GraphQLTestMixin(object):
             headers (dict)    - If provided, the headers in POST request to GRAPHQL_URL
                                 will be set to this value. Keys should be prepended with
                                 "HTTP_" (e.g. to specify the "Authorization" HTTP header,
-                                use "HTTP_AUTHORIZATION" as the key).       
+                                use "HTTP_AUTHORIZATION" as the key).
 
         Returns:
             Response object from client


### PR DESCRIPTION
The documentation makes several references to an `op_name` kwarg that is actually `operation_name`.