### PR TITLE
Updated deprecated variable name from format_error to GraphQLFormattedError

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -11,7 +11,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import View
 from graphql import OperationType, get_operation_ast, parse, validate
 from graphql.error import GraphQLError
-from graphql.error import format_error as format_graphql_error
+from graphql.error import GraphQLFormattedError as format_graphql_error
 from graphql.execution import ExecutionResult
 
 from graphene import Schema


### PR DESCRIPTION
While using `graphene-django`, I ran into the following `ImportError`:

`ImportError: cannot import name 'format_error' from 'graphql.error'`

Looking into `graphql.error`, here is an excerpt of `graphql-core`'s `/error/__init__.py` file:

```
__all__ = [
    "GraphQLError",
    "GraphQLErrorExtensions",
    "GraphQLFormattedError",
    "GraphQLSyntaxError",
    "located_error",
]
```

I believe `graphene_django/views.py`'s `format_error` variable name is most likely deprecated, so locally, I replaced `format_error` with `GraphQLFormattedError` from the excerpt above, and it is now working locally.

[Here](https://github.com/graphql-python/graphql-core/commit/09ff14f68bdce1e9cd71decc871fd38274b01971) is `graphql-core`'s commit that deprecated the `format_error` variable name