### PR TITLE
Update import name from format_error to graphql_error.format_error

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -11,7 +11,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import View
 from graphql import OperationType, get_operation_ast, parse, validate
 from graphql.error import GraphQLError
-from graphql.error import format_error as format_graphql_error
+from graphql.error.graphql_error import format_error as format_graphql_error
 from graphql.execution import ExecutionResult
 
 from graphene import Schema


### PR DESCRIPTION
When using graphene-django with `graphql-core 3.2.1`, I run into the following ImportError:

`ImportError: cannot import name 'format_error' from 'graphql.error'`

Seems format_error has been removed from the `error/__init__.py`, but it still exists. 
See also the discussion on https://github.com/graphql-python/graphene-django/pull/1320