### PR TITLE
👽 Use .formatted instead of format_error

### DIFF
--- a/graphene_django/filter/tests/test_array_field_exact_filter.py
+++ b/graphene_django/filter/tests/test_array_field_exact_filter.py
@@ -120,10 +120,7 @@ def test_array_field_filter_schema_type(Query):
         "randomField": "[Boolean!]",
     }
     filters_str = ", ".join(
-        [
-            f"{filter_field}: {gql_type} = null"
-            for filter_field, gql_type in filters.items()
-        ]
+        [f"{filter_field}: {gql_type}" for filter_field, gql_type in filters.items()]
     )
     assert (
         f"type Query {{\n  events({filters_str}): EventTypeConnection\n}}" in schema_str

--- a/graphene_django/filter/tests/test_enum_filtering.py
+++ b/graphene_django/filter/tests/test_enum_filtering.py
@@ -152,9 +152,6 @@ def test_filter_enum_field_schema_type(schema):
         "reporter_AChoice_In": "[TestsReporterAChoiceChoices]",
     }
     filters_str = ", ".join(
-        [
-            f"{filter_field}: {gql_type} = null"
-            for filter_field, gql_type in filters.items()
-        ]
+        [f"{filter_field}: {gql_type}" for filter_field, gql_type in filters.items()]
     )
     assert f"  allArticles({filters_str}): ArticleTypeConnection\n" in schema_str

--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -1008,7 +1008,7 @@ def test_integer_field_filter_type():
     assert str(schema) == dedent(
         """\
         type Query {
-          pets(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, age: Int = null): PetTypeConnection
+          pets(offset: Int, before: String, after: String, first: Int, last: Int, age: Int): PetTypeConnection
         }
 
         type PetTypeConnection {
@@ -1056,8 +1056,7 @@ def test_integer_field_filter_type():
         interface Node {
           \"""The ID of the object\"""
           id: ID!
-        }
-    """
+        }"""
     )
 
 
@@ -1077,7 +1076,7 @@ def test_other_filter_types():
     assert str(schema) == dedent(
         """\
         type Query {
-          pets(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, age: Int = null, age_Isnull: Boolean = null, age_Lt: Int = null): PetTypeConnection
+          pets(offset: Int, before: String, after: String, first: Int, last: Int, age: Int, age_Isnull: Boolean, age_Lt: Int): PetTypeConnection
         }
 
         type PetTypeConnection {
@@ -1125,8 +1124,7 @@ def test_other_filter_types():
         interface Node {
           \"""The ID of the object\"""
           id: ID!
-        }
-        """
+        }"""
     )
 
 

--- a/graphene_django/filter/tests/test_typed_filter.py
+++ b/graphene_django/filter/tests/test_typed_filter.py
@@ -98,7 +98,7 @@ def test_typed_filter_schema(schema):
     )
 
     for filter_field, gql_type in filters.items():
-        assert "{}: {} = null".format(filter_field, gql_type) in all_articles_filters
+        assert "{}: {}".format(filter_field, gql_type) in all_articles_filters
 
 
 def test_typed_filters_work(schema):

--- a/graphene_django/tests/test_command.py
+++ b/graphene_django/tests/test_command.py
@@ -53,6 +53,5 @@ def test_generate_graphql_file_on_call_graphql_schema():
         """\
         type Query {
           hi: String
-        }
-    """
+        }"""
     )

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -183,7 +183,7 @@ def test_schema_representation():
           pets: [Reporter!]!
           aChoice: TestsReporterAChoiceChoices
           reporterType: TestsReporterReporterTypeChoices
-          articles(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ArticleConnection!
+          articles(offset: Int, before: String, after: String, first: Int, last: Int): ArticleConnection!
         }
 
         \"""An enumeration.\"""
@@ -244,8 +244,7 @@ def test_schema_representation():
             \"""The ID of the object\"""
             id: ID!
           ): Node
-        }
-        """
+        }"""
     )
     assert str(schema) == expected
 
@@ -525,8 +524,7 @@ class TestDjangoObjectType:
               id: ID!
               kind: String!
               cuteness: Int!
-            }
-            """
+            }"""
         )
 
     def test_django_objecttype_convert_choices_enum_list(self, PetModel):
@@ -560,8 +558,7 @@ class TestDjangoObjectType:
 
               \"""Dog\"""
               DOG
-            }
-            """
+            }"""
         )
 
     def test_django_objecttype_convert_choices_enum_empty_list(self, PetModel):
@@ -586,8 +583,7 @@ class TestDjangoObjectType:
               id: ID!
               kind: String!
               cuteness: Int!
-            }
-            """
+            }"""
         )
 
     def test_django_objecttype_convert_choices_enum_naming_collisions(
@@ -621,8 +617,7 @@ class TestDjangoObjectType:
 
               \"""Dog\"""
               DOG
-            }
-            """
+            }"""
         )
 
     def test_django_objecttype_choices_custom_enum_name(
@@ -660,8 +655,7 @@ class TestDjangoObjectType:
 
               \"""Dog\"""
               DOG
-            }
-            """
+            }"""
         )
 
 

--- a/graphene_django/tests/test_views.py
+++ b/graphene_django/tests/test_views.py
@@ -109,12 +109,10 @@ def test_reports_validation_errors(client):
             {
                 "message": "Cannot query field 'unknownOne' on type 'QueryRoot'.",
                 "locations": [{"line": 1, "column": 9}],
-                "path": None,
             },
             {
                 "message": "Cannot query field 'unknownTwo' on type 'QueryRoot'.",
                 "locations": [{"line": 1, "column": 21}],
-                "path": None,
             },
         ]
     }
@@ -135,8 +133,6 @@ def test_errors_when_missing_operation_name(client):
         "errors": [
             {
                 "message": "Must provide operation name if query contains multiple operations.",
-                "locations": None,
-                "path": None,
             }
         ]
     }
@@ -477,7 +473,6 @@ def test_handles_syntax_errors_caught_by_graphql(client):
             {
                 "locations": [{"column": 1, "line": 1}],
                 "message": "Syntax Error: Unexpected Name 'syntaxerror'.",
-                "path": None,
             }
         ]
     }

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -11,7 +11,6 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import View
 from graphql import OperationType, get_operation_ast, parse, validate
 from graphql.error import GraphQLError
-from graphql.error import format_error as format_graphql_error
 from graphql.execution import ExecutionResult
 
 from graphene import Schema
@@ -387,7 +386,7 @@ class GraphQLView(View):
     @staticmethod
     def format_error(error):
         if isinstance(error, GraphQLError):
-            return format_graphql_error(error)
+            return error.formatted
 
         return {"message": str(error)}
 


### PR DESCRIPTION
This stops using the deprecated format_error removed in graphql-core v3.2 https://github.com/graphql-python/graphql-core/commit/09ff14f68bdce1e9cd71decc871fd38274b01971 . `GraphqlError.formatted` has been a thing since at least v1.

This PR tries to solve the same thing as #1326 and #1320.


Looks like there a missing newline in test output. Not sure if to update the tests or the code.