### PR TITLE
Fix: import dependency

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -11,7 +11,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import View
 from graphql import OperationType, get_operation_ast, parse, validate
 from graphql.error import GraphQLError
-from graphql.error import format_error as format_graphql_error
+from graphql.error.graphql_error import format_error as format_graphql_error
 from graphql.execution import ExecutionResult
 
 from graphene import Schema


### PR DESCRIPTION
```
File "/usr/local/lib/python3.9/site-packages/graphene_django/views.py", line 14, in <module>
  from graphql.error import format_error as format_graphql_error
ImportError: cannot import name 'format_error' from 'graphql.error' (/usr/local/lib/python3.9/site-packages/graphql/error/__init__.py)
```

This fixes the above bug.