### PR TITLE
Clarify cookbook example READMEs

### DIFF
--- a/examples/cookbook-plain/README.md
+++ b/examples/cookbook-plain/README.md
@@ -14,7 +14,7 @@ whole Graphene repository:
 ```bash
 # Get the example project code
 git clone https://github.com/graphql-python/graphene-django.git
-cd graphene-django/examples/cookbook
+cd graphene-django/examples/cookbook-plain
 ```
 
 It is good idea (but not required) to create a virtual environment

--- a/examples/cookbook/README.md
+++ b/examples/cookbook/README.md
@@ -1,4 +1,4 @@
-Cookbook Example Django Project
+Cookbook Example (Relay) Django Project
 ===============================
 
 This example project demos integration between Graphene and Django.
@@ -60,5 +60,5 @@ Now you should be ready to start the server:
 Now head on over to
 [http://127.0.0.1:8000/graphql](http://127.0.0.1:8000/graphql)
 and run some queries!
-(See the [Graphene-Django Tutorial](http://docs.graphene-python.org/projects/django/en/latest/tutorial-plain/#testing-our-graphql-schema)
+(See the [Graphene-Django Tutorial](http://docs.graphene-python.org/projects/django/en/latest/tutorial-relay/#testing-our-graphql-schema)
 for some example queries)


### PR DESCRIPTION
Currently the relay cookbook's readme has a link to the plain tutorial page. The plain cookbook readme also instructs the user to change directory into the directory for the relay example. This change fixes both issues.

Also changed the title for the relay example to specify that it uses relay.