### PR TITLE
Fix schema print with `-.graphql`

### DIFF
--- a/graphene_django/management/commands/graphql_schema.py
+++ b/graphene_django/management/commands/graphql_schema.py
@@ -63,7 +63,7 @@ class Command(CommandArguments):
         if out == "-" or out == "-.json":
             self.stdout.write(json.dumps(schema_dict, indent=indent, sort_keys=True))
         elif out == "-.graphql":
-            self.stdout.write(print_schema(schema))
+            self.stdout.write(print_schema(schema.graphql_schema))
         else:
             # Determine format
             _, file_extension = os.path.splitext(out)


### PR DESCRIPTION
Hi, we recently made to move to v3 and came across this problem. When printing the schema using the management command:
```
./manage.py graphql_schema --out=-.graphql
```
It thows an error:
```
AttributeError: Type "directives" not found in the Schema
```

The issue has been addressed [here](https://github.com/graphql-python/graphene-django/issues/1089) with the suggested fix implemented in this PR.