### PR TITLE
feat: support django 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,21 @@
+.PHONY: help
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@grep -E '^\.PHONY: [a-zA-Z_-]+ .*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = "(: |##)"}; {printf "\033[36m%-30s\033[0m %s\n", $$2, $$3}'
+
 .PHONY: dev-setup ## Install development dependencies
 dev-setup:
 	pip install -e ".[dev]"
 
-.PHONY: install-dev
-install-dev: dev-setup  # Alias install-dev -> dev-setup
-
-.PHONY: tests
+.PHONY: tests ## Run unit tests
 tests:
 	py.test graphene_django --cov=graphene_django -vv
 
-.PHONY: test
-test: tests  # Alias test -> tests
-
-.PHONY: format
+.PHONY: format ## Format code
 format:
 	black --exclude "/migrations/" graphene_django examples setup.py
 
-.PHONY: lint
+.PHONY: lint ## Lint code
 lint:
 	flake8 graphene_django examples
 

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -24,6 +24,7 @@ from graphene import (
     Decimal,
 )
 from graphene.types.json import JSONString
+from graphene.types.scalars import BigInt
 from graphene.utils.str_converters import to_camel_case
 from graphql import GraphQLError, assert_valid_name
 from graphql.pyutils import register_description
@@ -186,10 +187,14 @@ def convert_field_to_uuid(field, registry=None):
     )
 
 
+@convert_django_field.register(models.BigIntegerField)
+def convert_big_int_field(field, registry=None):
+    return BigInt(description=field.help_text, required=not field.null)
+
+
 @convert_django_field.register(models.PositiveIntegerField)
 @convert_django_field.register(models.PositiveSmallIntegerField)
 @convert_django_field.register(models.SmallIntegerField)
-@convert_django_field.register(models.BigIntegerField)
 @convert_django_field.register(models.IntegerField)
 def convert_field_to_int(field, registry=None):
     return Int(description=get_django_field_description(field), required=not field.null)

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -306,7 +306,24 @@ def convert_field_to_djangomodel(field, registry=None):
         if not _type:
             return
 
-        return Field(
+        class CustomField(Field):
+            def wrap_resolve(self, parent_resolver):
+                """
+                Implements a custom resolver which go through the `get_node` method to insure that
+                it goes through the `get_queryset` method of the DjangoObjectType.
+                """
+                resolver = super().wrap_resolve(parent_resolver)
+
+                def custom_resolver(root, info, **args):
+                    fk_obj = resolver(root, info, **args)
+                    if fk_obj is None:
+                        return None
+                    else:
+                        return _type.get_node(info, fk_obj.pk)
+
+                return custom_resolver
+
+        return CustomField(
             _type,
             description=get_django_field_description(field),
             required=not field.null,

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -69,7 +69,10 @@ class DjangoListField(Field):
             _type = _type.of_type
         django_object_type = _type.of_type.of_type
         return partial(
-            self.list_resolver, django_object_type, resolver, self.get_manager(),
+            self.list_resolver,
+            django_object_type,
+            resolver,
+            self.get_manager(),
         )
 
 

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -152,22 +152,24 @@ class DjangoConnectionField(ConnectionField):
             array_length = iterable.count()
         else:
             array_length = len(iterable)
-        array_slice_length = (
-            min(max_limit, array_length) if max_limit is not None else array_length
-        )
 
-        # If after is higher than list_length, connection_from_list_slice
+        # If after is higher than array_length, connection_from_array_slice
         # would try to do a negative slicing which makes django throw an
         # AssertionError
         slice_start = min(
-            get_offset_with_default(args.get("after"), -1) + 1, array_length
+            get_offset_with_default(args.get("after"), -1) + 1,
+            array_length,
         )
+        array_slice_length = array_length - slice_start
 
-        if max_limit is not None and args.get("first", None) is None:
-            if args.get("last", None) is not None:
-                slice_start = max(array_length - args["last"], 0)
-            else:
-                args["first"] = max_limit
+        # Impose the maximum limit via the `first`` field if neither first or last are already provided
+        # (note that if any of them is provided they must be under max_limit otherwise an error is raised).
+        if (
+            max_limit is not None
+            and args.get("first", None) is None
+            and args.get("last", None) is None
+        ):
+            args["first"] = max_limit
 
         connection = connection_from_array_slice(
             iterable[slice_start:],

--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -30,7 +30,7 @@ def convert_enum(data):
 class DjangoFilterConnectionField(DjangoConnectionField):
     def __init__(
         self,
-        type,
+        type_,
         fields=None,
         order_by=None,
         extra_filter_meta=None,
@@ -44,7 +44,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         self._filtering_args = None
         self._extra_filter_meta = extra_filter_meta
         self._base_args = None
-        super(DjangoFilterConnectionField, self).__init__(type, *args, **kwargs)
+        super(DjangoFilterConnectionField, self).__init__(type_, *args, **kwargs)
 
     @property
     def args(self):

--- a/graphene_django/filter/filters/global_id_filter.py
+++ b/graphene_django/filter/filters/global_id_filter.py
@@ -13,7 +13,7 @@ class GlobalIDFilter(Filter):
     field_class = GlobalIDFormField
 
     def filter(self, qs, value):
-        """ Convert the filter value to a primary key before filtering """
+        """Convert the filter value to a primary key before filtering"""
         _id = None
         if value is not None:
             _, _id = from_global_id(value)

--- a/graphene_django/filter/filterset.py
+++ b/graphene_django/filter/filterset.py
@@ -18,8 +18,8 @@ GRAPHENE_FILTER_SET_OVERRIDES = {
 
 
 class GrapheneFilterSetMixin(BaseFilterSet):
-    """ A django_filters.filterset.BaseFilterSet with default filter overrides
-    to handle global IDs """
+    """A django_filters.filterset.BaseFilterSet with default filter overrides
+    to handle global IDs"""
 
     FILTER_DEFAULTS = dict(
         itertools.chain(
@@ -29,8 +29,7 @@ class GrapheneFilterSetMixin(BaseFilterSet):
 
 
 def setup_filterset(filterset_class):
-    """ Wrap a provided filterset in Graphene-specific functionality
-    """
+    """Wrap a provided filterset in Graphene-specific functionality"""
     return type(
         "Graphene{}".format(filterset_class.__name__),
         (filterset_class, GrapheneFilterSetMixin),
@@ -39,8 +38,7 @@ def setup_filterset(filterset_class):
 
 
 def custom_filterset_factory(model, filterset_base_class=FilterSet, **meta):
-    """ Create a filterset for the given model using the provided meta data
-    """
+    """Create a filterset for the given model using the provided meta data"""
     meta.update({"model": model})
     meta_class = type(str("Meta"), (object,), meta)
     filterset = type(

--- a/graphene_django/filter/tests/conftest.py
+++ b/graphene_django/filter/tests/conftest.py
@@ -89,10 +89,10 @@ def Query(EventType):
         def resolve_events(self, info, **kwargs):
 
             events = [
-                Event(name="Live Show", tags=["concert", "music", "rock"],),
-                Event(name="Musical", tags=["movie", "music"],),
-                Event(name="Ballet", tags=["concert", "dance"],),
-                Event(name="Speech", tags=[],),
+                Event(name="Live Show", tags=["concert", "music", "rock"]),
+                Event(name="Musical", tags=["movie", "music"]),
+                Event(name="Ballet", tags=["concert", "dance"]),
+                Event(name="Speech", tags=[]),
             ]
 
             STORE["events"] = events

--- a/graphene_django/filter/tests/test_enum_filtering.py
+++ b/graphene_django/filter/tests/test_enum_filtering.py
@@ -54,13 +54,13 @@ def reporter_article_data():
         first_name="Jane", last_name="Doe", email="janedoe@example.com", a_choice=2
     )
     Article.objects.create(
-        headline="Article Node 1", reporter=john, editor=john, lang="es",
+        headline="Article Node 1", reporter=john, editor=john, lang="es"
     )
     Article.objects.create(
-        headline="Article Node 2", reporter=john, editor=john, lang="en",
+        headline="Article Node 2", reporter=john, editor=john, lang="en"
     )
     Article.objects.create(
-        headline="Article Node 3", reporter=jane, editor=jane, lang="en",
+        headline="Article Node 3", reporter=jane, editor=jane, lang="en"
     )
 
 
@@ -80,7 +80,13 @@ def test_filter_enum_on_connection(schema, reporter_article_data):
         }
     """
 
-    expected = {"allArticles": {"edges": [{"node": {"headline": "Article Node 1"}},]}}
+    expected = {
+        "allArticles": {
+            "edges": [
+                {"node": {"headline": "Article Node 1"}},
+            ]
+        }
+    }
 
     result = schema.execute(query)
     assert not result.errors

--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -1224,7 +1224,7 @@ def test_filter_filterset_based_on_mixin():
         }
     }
 
-    result = schema.execute(query, variable_values={"email": reporter_1.email},)
+    result = schema.execute(query, variable_values={"email": reporter_1.email})
 
     assert not result.errors
     assert result.data == expected
@@ -1265,13 +1265,23 @@ def test_filter_string_contains():
     result = schema.execute(query, variables={"filter": "Ja"})
     assert not result.errors
     assert result.data == {
-        "people": {"edges": [{"node": {"name": "Jack"}}, {"node": {"name": "Jane"}},]}
+        "people": {
+            "edges": [
+                {"node": {"name": "Jack"}},
+                {"node": {"name": "Jane"}},
+            ]
+        }
     }
 
     result = schema.execute(query, variables={"filter": "o"})
     assert not result.errors
     assert result.data == {
-        "people": {"edges": [{"node": {"name": "Joe"}}, {"node": {"name": "Bob"}},]}
+        "people": {
+            "edges": [
+                {"node": {"name": "Joe"}},
+                {"node": {"name": "Bob"}},
+            ]
+        }
     }
 
 

--- a/graphene_django/filter/tests/test_typed_filter.py
+++ b/graphene_django/filter/tests/test_typed_filter.py
@@ -103,15 +103,9 @@ def test_typed_filter_schema(schema):
 
 def test_typed_filters_work(schema):
     reporter = Reporter.objects.create(first_name="John", last_name="Doe", email="")
-    Article.objects.create(
-        headline="A", reporter=reporter, editor=reporter, lang="es",
-    )
-    Article.objects.create(
-        headline="B", reporter=reporter, editor=reporter, lang="es",
-    )
-    Article.objects.create(
-        headline="C", reporter=reporter, editor=reporter, lang="en",
-    )
+    Article.objects.create(headline="A", reporter=reporter, editor=reporter, lang="es")
+    Article.objects.create(headline="B", reporter=reporter, editor=reporter, lang="es")
+    Article.objects.create(headline="C", reporter=reporter, editor=reporter, lang="en")
 
     query = "query { articles (lang_In: [ES]) { edges { node { headline } } } }"
 

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -94,7 +94,9 @@ def get_filtering_args_from_filterset(filterset_class, type):
                 field_type = graphene.List(field_type)
 
         args[name] = graphene.Argument(
-            field_type, description=filter_field.label, required=required,
+            field_type,
+            description=filter_field.label,
+            required=required,
         )
 
     return args

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -13,6 +13,9 @@ class Person(models.Model):
 class Pet(models.Model):
     name = models.CharField(max_length=30)
     age = models.PositiveIntegerField()
+    owner = models.ForeignKey(
+        "Person", on_delete=models.CASCADE, null=True, blank=True, related_name="pets"
+    )
 
 
 class FilmDetails(models.Model):

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -10,6 +10,7 @@ from graphene import NonNull
 from graphene.relay import ConnectionField, Node
 from graphene.types.datetime import Date, DateTime, Time
 from graphene.types.json import JSONString
+from graphene.types.scalars import BigInt
 
 from ..compat import (
     ArrayField,
@@ -140,8 +141,8 @@ def test_should_small_integer_convert_int():
     assert_conversion(models.SmallIntegerField, graphene.Int)
 
 
-def test_should_big_integer_convert_int():
-    assert_conversion(models.BigIntegerField, graphene.Int)
+def test_should_big_integer_convert_big_int():
+    assert_conversion(models.BigIntegerField, BigInt)
 
 
 def test_should_integer_convert_int():

--- a/graphene_django/tests/test_get_queryset.py
+++ b/graphene_django/tests/test_get_queryset.py
@@ -1,0 +1,361 @@
+import pytest
+
+import graphene
+from graphene.relay import Node
+
+from graphql_relay import to_global_id
+
+from ..fields import DjangoConnectionField
+from ..types import DjangoObjectType
+
+from .models import Article, Reporter
+
+
+class TestShouldCallGetQuerySetOnForeignKey:
+    """
+    Check that the get_queryset method is called in both forward and reversed direction
+    of a foreignkey on types.
+    (see issue #1111)
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_schema(self):
+        class ReporterType(DjangoObjectType):
+            class Meta:
+                model = Reporter
+
+            @classmethod
+            def get_queryset(cls, queryset, info):
+                if info.context and info.context.get("admin"):
+                    return queryset
+                raise Exception("Not authorized to access reporters.")
+
+        class ArticleType(DjangoObjectType):
+            class Meta:
+                model = Article
+
+            @classmethod
+            def get_queryset(cls, queryset, info):
+                return queryset.exclude(headline__startswith="Draft")
+
+        class Query(graphene.ObjectType):
+            reporter = graphene.Field(ReporterType, id=graphene.ID(required=True))
+            article = graphene.Field(ArticleType, id=graphene.ID(required=True))
+
+            def resolve_reporter(self, info, id):
+                return (
+                    ReporterType.get_queryset(Reporter.objects, info)
+                    .filter(id=id)
+                    .last()
+                )
+
+            def resolve_article(self, info, id):
+                return (
+                    ArticleType.get_queryset(Article.objects, info).filter(id=id).last()
+                )
+
+        self.schema = graphene.Schema(query=Query)
+
+        self.reporter = Reporter.objects.create(first_name="Jane", last_name="Doe")
+
+        self.articles = [
+            Article.objects.create(
+                headline="A fantastic article",
+                reporter=self.reporter,
+                editor=self.reporter,
+            ),
+            Article.objects.create(
+                headline="Draft: My next best seller",
+                reporter=self.reporter,
+                editor=self.reporter,
+            ),
+        ]
+
+    def test_get_queryset_called_on_field(self):
+        # If a user tries to access an article it is fine as long as it's not a draft one
+        query = """
+            query getArticle($id: ID!) {
+                article(id: $id) {
+                    headline
+                }
+            }
+        """
+        # Non-draft
+        result = self.schema.execute(query, variables={"id": self.articles[0].id})
+        assert not result.errors
+        assert result.data["article"] == {
+            "headline": "A fantastic article",
+        }
+        # Draft
+        result = self.schema.execute(query, variables={"id": self.articles[1].id})
+        assert not result.errors
+        assert result.data["article"] is None
+
+        # If a non admin user tries to access a reporter they should get our authorization error
+        query = """
+            query getReporter($id: ID!) {
+                reporter(id: $id) {
+                    firstName
+                }
+            }
+        """
+
+        result = self.schema.execute(query, variables={"id": self.reporter.id})
+        assert len(result.errors) == 1
+        assert result.errors[0].message == "Not authorized to access reporters."
+
+        # An admin user should be able to get reporters
+        query = """
+            query getReporter($id: ID!) {
+                reporter(id: $id) {
+                    firstName
+                }
+            }
+        """
+
+        result = self.schema.execute(
+            query,
+            variables={"id": self.reporter.id},
+            context_value={"admin": True},
+        )
+        assert not result.errors
+        assert result.data == {"reporter": {"firstName": "Jane"}}
+
+    def test_get_queryset_called_on_foreignkey(self):
+        # If a user tries to access a reporter through an article they should get our authorization error
+        query = """
+            query getArticle($id: ID!) {
+                article(id: $id) {
+                    headline
+                    reporter {
+                        firstName
+                    }
+                }
+            }
+        """
+
+        result = self.schema.execute(query, variables={"id": self.articles[0].id})
+        assert len(result.errors) == 1
+        assert result.errors[0].message == "Not authorized to access reporters."
+
+        # An admin user should be able to get reporters through an article
+        query = """
+            query getArticle($id: ID!) {
+                article(id: $id) {
+                    headline
+                    reporter {
+                        firstName
+                    }
+                }
+            }
+        """
+
+        result = self.schema.execute(
+            query,
+            variables={"id": self.articles[0].id},
+            context_value={"admin": True},
+        )
+        assert not result.errors
+        assert result.data["article"] == {
+            "headline": "A fantastic article",
+            "reporter": {"firstName": "Jane"},
+        }
+
+        # An admin user should not be able to access draft article through a reporter
+        query = """
+            query getReporter($id: ID!) {
+                reporter(id: $id) {
+                    firstName
+                    articles {
+                        headline
+                    }
+                }
+            }
+        """
+
+        result = self.schema.execute(
+            query,
+            variables={"id": self.reporter.id},
+            context_value={"admin": True},
+        )
+        assert not result.errors
+        assert result.data["reporter"] == {
+            "firstName": "Jane",
+            "articles": [{"headline": "A fantastic article"}],
+        }
+
+
+class TestShouldCallGetQuerySetOnForeignKeyNode:
+    """
+    Check that the get_queryset method is called in both forward and reversed direction
+    of a foreignkey on types using a node interface.
+    (see issue #1111)
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_schema(self):
+        class ReporterType(DjangoObjectType):
+            class Meta:
+                model = Reporter
+                interfaces = (Node,)
+
+            @classmethod
+            def get_queryset(cls, queryset, info):
+                if info.context and info.context.get("admin"):
+                    return queryset
+                raise Exception("Not authorized to access reporters.")
+
+        class ArticleType(DjangoObjectType):
+            class Meta:
+                model = Article
+                interfaces = (Node,)
+
+            @classmethod
+            def get_queryset(cls, queryset, info):
+                return queryset.exclude(headline__startswith="Draft")
+
+        class Query(graphene.ObjectType):
+            reporter = Node.Field(ReporterType)
+            article = Node.Field(ArticleType)
+
+        self.schema = graphene.Schema(query=Query)
+
+        self.reporter = Reporter.objects.create(first_name="Jane", last_name="Doe")
+
+        self.articles = [
+            Article.objects.create(
+                headline="A fantastic article",
+                reporter=self.reporter,
+                editor=self.reporter,
+            ),
+            Article.objects.create(
+                headline="Draft: My next best seller",
+                reporter=self.reporter,
+                editor=self.reporter,
+            ),
+        ]
+
+    def test_get_queryset_called_on_node(self):
+        # If a user tries to access an article it is fine as long as it's not a draft one
+        query = """
+            query getArticle($id: ID!) {
+                article(id: $id) {
+                    headline
+                }
+            }
+        """
+        # Non-draft
+        result = self.schema.execute(
+            query, variables={"id": to_global_id("ArticleType", self.articles[0].id)}
+        )
+        assert not result.errors
+        assert result.data["article"] == {
+            "headline": "A fantastic article",
+        }
+        # Draft
+        result = self.schema.execute(
+            query, variables={"id": to_global_id("ArticleType", self.articles[1].id)}
+        )
+        assert not result.errors
+        assert result.data["article"] is None
+
+        # If a non admin user tries to access a reporter they should get our authorization error
+        query = """
+            query getReporter($id: ID!) {
+                reporter(id: $id) {
+                    firstName
+                }
+            }
+        """
+
+        result = self.schema.execute(
+            query, variables={"id": to_global_id("ReporterType", self.reporter.id)}
+        )
+        assert len(result.errors) == 1
+        assert result.errors[0].message == "Not authorized to access reporters."
+
+        # An admin user should be able to get reporters
+        query = """
+            query getReporter($id: ID!) {
+                reporter(id: $id) {
+                    firstName
+                }
+            }
+        """
+
+        result = self.schema.execute(
+            query,
+            variables={"id": to_global_id("ReporterType", self.reporter.id)},
+            context_value={"admin": True},
+        )
+        assert not result.errors
+        assert result.data == {"reporter": {"firstName": "Jane"}}
+
+    def test_get_queryset_called_on_foreignkey(self):
+        # If a user tries to access a reporter through an article they should get our authorization error
+        query = """
+            query getArticle($id: ID!) {
+                article(id: $id) {
+                    headline
+                    reporter {
+                        firstName
+                    }
+                }
+            }
+        """
+
+        result = self.schema.execute(
+            query, variables={"id": to_global_id("ArticleType", self.articles[0].id)}
+        )
+        assert len(result.errors) == 1
+        assert result.errors[0].message == "Not authorized to access reporters."
+
+        # An admin user should be able to get reporters through an article
+        query = """
+            query getArticle($id: ID!) {
+                article(id: $id) {
+                    headline
+                    reporter {
+                        firstName
+                    }
+                }
+            }
+        """
+
+        result = self.schema.execute(
+            query,
+            variables={"id": to_global_id("ArticleType", self.articles[0].id)},
+            context_value={"admin": True},
+        )
+        assert not result.errors
+        assert result.data["article"] == {
+            "headline": "A fantastic article",
+            "reporter": {"firstName": "Jane"},
+        }
+
+        # An admin user should not be able to access draft article through a reporter
+        query = """
+            query getReporter($id: ID!) {
+                reporter(id: $id) {
+                    firstName
+                    articles {
+                        edges {
+                            node {
+                                headline
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        result = self.schema.execute(
+            query,
+            variables={"id": to_global_id("ReporterType", self.reporter.id)},
+            context_value={"admin": True},
+        )
+        assert not result.errors
+        assert result.data["reporter"] == {
+            "firstName": "Jane",
+            "articles": {"edges": [{"node": {"headline": "A fantastic article"}}]},
+        }

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -1480,7 +1480,11 @@ def test_connection_should_enable_offset_filtering():
     result = schema.execute(query)
     assert not result.errors
     expected = {
-        "allReporters": {"edges": [{"node": {"firstName": "Some", "lastName": "Guy"}},]}
+        "allReporters": {
+            "edges": [
+                {"node": {"firstName": "Some", "lastName": "Guy"}},
+            ]
+        }
     }
     assert result.data == expected
 
@@ -1521,7 +1525,9 @@ def test_connection_should_enable_offset_filtering_higher_than_max_limit(
     assert not result.errors
     expected = {
         "allReporters": {
-            "edges": [{"node": {"firstName": "Some", "lastName": "Lady"}},]
+            "edges": [
+                {"node": {"firstName": "Some", "lastName": "Lady"}},
+            ]
         }
     }
     assert result.data == expected
@@ -1590,7 +1596,11 @@ def test_connection_should_allow_offset_filtering_with_after():
     result = schema.execute(query, variable_values=dict(after=after))
     assert not result.errors
     expected = {
-        "allReporters": {"edges": [{"node": {"firstName": "Jane", "lastName": "Roe"}},]}
+        "allReporters": {
+            "edges": [
+                {"node": {"firstName": "Jane", "lastName": "Roe"}},
+            ]
+        }
     }
     assert result.data == expected
 

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -15,7 +15,7 @@ from ..compat import IntegerRangeField, MissingType
 from ..fields import DjangoConnectionField
 from ..types import DjangoObjectType
 from ..utils import DJANGO_FILTER_INSTALLED
-from .models import Article, CNNReporter, Film, FilmDetails, Reporter
+from .models import Article, CNNReporter, Film, FilmDetails, Person, Pet, Reporter
 
 
 def test_should_query_only_fields():
@@ -251,8 +251,8 @@ def test_should_node():
 
 
 def test_should_query_onetoone_fields():
-    film = Film(id=1)
-    film_details = FilmDetails(id=1, film=film)
+    film = Film.objects.create(id=1)
+    film_details = FilmDetails.objects.create(id=1, film=film)
 
     class FilmNode(DjangoObjectType):
         class Meta:
@@ -1678,3 +1678,68 @@ def test_connection_should_succeed_if_last_higher_than_number_of_objects():
         }
     }
     assert result.data == expected
+
+
+def test_should_query_nullable_foreign_key():
+    class PetType(DjangoObjectType):
+        class Meta:
+            model = Pet
+
+    class PersonType(DjangoObjectType):
+        class Meta:
+            model = Person
+
+    class Query(graphene.ObjectType):
+        pet = graphene.Field(PetType, name=graphene.String(required=True))
+        person = graphene.Field(PersonType, name=graphene.String(required=True))
+
+        def resolve_pet(self, info, name):
+            return Pet.objects.filter(name=name).first()
+
+        def resolve_person(self, info, name):
+            return Person.objects.filter(name=name).first()
+
+    schema = graphene.Schema(query=Query)
+
+    person = Person.objects.create(name="Jane")
+    pets = [
+        Pet.objects.create(name="Stray dog", age=1),
+        Pet.objects.create(name="Jane's dog", owner=person, age=1),
+    ]
+
+    query_pet = """
+        query getPet($name: String!) {
+            pet(name: $name) {
+                owner {
+                    name
+                }
+            }
+        }
+    """
+
+    result = schema.execute(query_pet, variables={"name": "Stray dog"})
+    assert not result.errors
+    assert result.data["pet"] == {
+        "owner": None,
+    }
+
+    result = schema.execute(query_pet, variables={"name": "Jane's dog"})
+    assert not result.errors
+    assert result.data["pet"] == {
+        "owner": {"name": "Jane"},
+    }
+
+    query_owner = """
+        query getOwner($name: String!) {
+            person(name: $name) {
+                pets {
+                    name
+                }
+            }
+        }
+    """
+    result = schema.execute(query_owner, variables={"name": "Jane"})
+    assert not result.errors
+    assert result.data["person"] == {
+        "pets": [{"name": "Jane's dog"}],
+    }

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -216,7 +216,7 @@ class DjangoObjectType(ObjectType):
                 "Creating a DjangoObjectType without either the `fields` "
                 "or the `exclude` option is deprecated. Add an explicit `fields "
                 "= '__all__'` option on DjangoObjectType {class_name} to use all "
-                "fields".format(class_name=cls.__name__,),
+                "fields".format(class_name=cls.__name__),
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/graphene_django/utils/tests/test_str_converters.py
+++ b/graphene_django/utils/tests/test_str_converters.py
@@ -6,4 +6,4 @@ def test_to_const():
 
 
 def test_to_const_unicode():
-    assert to_const(u"Skoða þetta unicode stöff") == "SKODA_THETTA_UNICODE_STOFF"
+    assert to_const("Skoða þetta unicode stöff") == "SKODA_THETTA_UNICODE_STOFF"

--- a/setup.py
+++ b/setup.py
@@ -14,22 +14,22 @@ rest_framework_require = ["djangorestframework>=3.6.3"]
 
 
 tests_require = [
-    "pytest>=3.6.3",
+    "pytest>=7.1.3",
     "pytest-cov",
     "pytest-random-order",
     "coveralls",
     "mock",
     "pytz",
-    "django-filter>=2",
-    "pytest-django>=3.3.2",
+    "django-filter>=22.1",
+    "pytest-django>=4.5.2",
 ] + rest_framework_require
 
 
 dev_requires = [
-    "black==19.10b0",
-    "flake8==3.7.9",
-    "flake8-black==0.1.1",
-    "flake8-bugbear==20.1.4",
+    "black==22.8.0",
+    "flake8==5.0.4",
+    "flake8-black==0.3.3",
+    "flake8-bugbear==22.9.11",
 ] + tests_require
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,9 @@ setup(
     keywords="api graphql protocol rest relay graphene",
     packages=find_packages(exclude=["tests", "examples", "examples.*"]),
     install_requires=[
-        "graphene>=3.0,<4",
+        "graphene @ git+https://github.com/graphql-python/graphene.git@ee1ff975d71f6590eb6933d76d12054c9839774a#egg=graphene",
         "graphql-core>=3.1.0,<4",
-        "graphql-relay>=3.1.1,<4",
+        "graphql-relay @ git+https://github.com/loft-orbital/graphql-relay-py.git@loft-v3.2.0-1#egg=graphql-relay",
         "Django>=3.2",
         "promise>=2.1",
         "text-unidecode",


### PR DESCRIPTION
## Main change

* Relax constraint to support django 2.2

## Other changes

**I had to batch replace `py.test` by `pytest` for `make tests` to pass locally.** :
* This has also been applied in the main graphene-django repo last month
* Ref: graphene-django commit: https://github.com/graphql-python/graphene-django/commit/86c5309c4537b8f898a4cf8f2b516efa14be18f8 and  https://github.com/pytest-dev/pytest/issues/10459