### PR TITLE
graphiql  v1.4.7 security update

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -66,9 +66,9 @@ class GraphQLView(View):
     react_dom_sri = "sha256-nbMykgB6tsOFJ7OdVmPpdqMFVk4ZsqWocT6issAPUF0="
 
     # The GraphiQL React app.
-    graphiql_version = "1.4.1"  # "1.0.3"
-    graphiql_sri = "sha256-JUMkXBQWZMfJ7fGEsTXalxVA10lzKOS9loXdLjwZKi4="  # "sha256-VR4buIDY9ZXSyCNFHFNik6uSe0MhigCzgN4u7moCOTk="
-    graphiql_css_sri = "sha256-Md3vdR7PDzWyo/aGfsFVF4tvS5/eAUWuIsg9QHUusCY="  # "sha256-LwqxjyZgqXDYbpxQJ5zLQeNcf7WVNSJ+r8yp2rnWE/E="
+    graphiql_version = "1.4.7"  # "1.0.3"
+    graphiql_sri = "sha256-cpZ8w9D/i6XdEbY/Eu7yAXeYzReVw0mxYd7OU3gUcsc="  # "sha256-VR4buIDY9ZXSyCNFHFNik6uSe0MhigCzgN4u7moCOTk="
+    graphiql_css_sri = "sha256-HADQowUuFum02+Ckkv5Yu5ygRoLllHZqg0TFZXY7NHI="  # "sha256-LwqxjyZgqXDYbpxQJ5zLQeNcf7WVNSJ+r8yp2rnWE/E="
 
     # The websocket transport library for subscriptions.
     subscriptions_transport_ws_version = "0.9.18"


### PR DESCRIPTION
From [graphql/graphiql](https://github.com/graphql/graphiql)

> Security Notice: All versions of graphiql < 1.4.7 are vulnerable to an XSS attack in cases where the GraphQL server to which the GraphiQL web app connects is not trusted.

After reading the report [here](https://github.com/graphql/graphiql/blob/main/docs/security/2021-introspection-schema-xss.md) I'm not too sure if graphene-django is vulnerable to this attack but it might be worth updating just in case.