### PR TITLE
Remove promise based debug middleware

### DIFF
--- a/graphene_django/debug/middleware.py
+++ b/graphene_django/debug/middleware.py
@@ -9,32 +9,32 @@ from .types import DjangoDebug
 
 class DjangoDebugContext:
     def __init__(self):
-        self.debug_promise = None
-        self.promises = []
+        self.debug_result = None
+        self.results = []
         self.object = DjangoDebug(sql=[], exceptions=[])
         self.enable_instrumentation()
 
-    def get_debug_promise(self):
-        if not self.debug_promise:
-            self.debug_promise = Promise.all(self.promises)
-            self.promises = []
-        return self.debug_promise.then(self.on_resolve_all_promises).get()
+    def get_debug_result(self):
+        if not self.debug_result:
+            self.debug_result = self.results
+            self.results = []
+        return self.on_resolve_all_results()
 
     def on_resolve_error(self, value):
         if hasattr(self, "object"):
             self.object.exceptions.append(wrap_exception(value))
-        return Promise.reject(value)
+        return value
 
-    def on_resolve_all_promises(self, values):
-        if self.promises:
-            self.debug_promise = None
-            return self.get_debug_promise()
+    def on_resolve_all_results(self):
+        if self.results:
+            self.debug_result = None
+            return self.get_debug_result()
         self.disable_instrumentation()
         return self.object
 
-    def add_promise(self, promise):
-        if self.debug_promise:
-            self.promises.append(promise)
+    def add_result(self, result):
+        if self.debug_result:
+            self.results.append(result)
 
     def enable_instrumentation(self):
         # This is thread-safe because database connections are thread-local.
@@ -62,10 +62,10 @@ class DjangoDebugMiddleware:
                     )
                 )
         if info.schema.get_type("DjangoDebug") == info.return_type:
-            return context.django_debug.get_debug_promise()
+            return context.django_debug.get_debug_result()
         try:
-            promise = next(root, info, **args)
+            result = next(root, info, **args)
         except Exception as e:
             return context.django_debug.on_resolve_error(e)
-        context.django_debug.add_promise(promise)
-        return promise
+        context.django_debug.add_result(result)
+        return result

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ passenv = *
 usedevelop = True
 setenv =
     DJANGO_SETTINGS_MODULE=examples.django_test_settings
+    PYTHONPATH=.
 deps =
     -e.[test]
     psycopg2-binary


### PR DESCRIPTION
The exception handling by the debug middleware is broken. If using the toolbar middleware, then any exception raised in a resolver gets consumed and replaced with a cryptic `Thread pool` related error.

The root cause is that the graphql core lib expects the result of the call to exception instance rather than a rejected promise.

When the graphql core lib tries to resolve the promise as a normal result it results in the cryptic error.

I've also removed the reference to promises as they didn't seem to be helping anything (But please correct the PR if I'm missing something)