### PR TITLE
fix(converter.py): performance fix in `convert_field_to_djangomodel.dynamic_type.CustomField

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -358,7 +358,10 @@ def convert_field_to_djangomodel(field, registry=None):
                     if instance_from_get_node is None:
                         # no instance to return
                         return
-                    elif isinstance(resolver, functools.partial) and resolver.func is get_default_resolver():
+                    elif (
+                        isinstance(resolver, functools.partial) 
+                        and resolver.func is get_default_resolver()
+                    ):
                         return instance_from_get_node
                     elif resolver is not get_default_resolver():
                         # Default resolver is overriden

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -359,7 +359,7 @@ def convert_field_to_djangomodel(field, registry=None):
                         # no instance to return
                         return
                     elif (
-                        isinstance(resolver, functools.partial) 
+                        isinstance(resolver, functools.partial)
                         and resolver.func is get_default_resolver()
                     ):
                         return instance_from_get_node


### PR DESCRIPTION
Fix performance issue in resolving one-to-one and foreign-key field, make only one database hit to get the field instance while resolving the field.