### PR TITLE
Add pre-commit to dev-setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ help:
 .PHONY: dev-setup ## Install development dependencies
 dev-setup:
 	pip install -e ".[dev]"
+	python -m pre_commit install
 
 .PHONY: tests ## Run unit tests
 tests:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ dev_requires = [
     "flake8==5.0.4",
     "flake8-black==0.3.3",
     "flake8-bugbear==22.9.11",
+    "pre-commit",
 ] + tests_require
 
 setup(


### PR DESCRIPTION
pre-commit is currently configured nicely but hasn't been part of the Makefile setup and isn't mentioned in the contributing notes. This change makes it so that pre-commit is installed as a part of the dev setup, whereas before it had to be manually installed.

Let me know if we should start pinning the pre-commit version, and/or if this should be added to a separate Makefile task.