### PR TITLE
fix: fix graphiql request failure

### DIFF
--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -60,39 +60,26 @@
 
   function trueLambda() { return true; };
 
-  var fetcher = GraphiQL.createFetcher({
+  var headers = {};
+  var cookies = ("; " + document.cookie).split("; csrftoken=");
+  if (cookies.length == 2) {
+    csrftoken = cookies.pop().split(";").shift();
+  } else {
+    csrftoken = document.querySelector("[name=csrfmiddlewaretoken]").value;
+  }
+  if (csrftoken) {
+    headers['X-CSRFToken'] = csrftoken
+  }
+
+  var graphQLFetcher = GraphiQL.createFetcher({
     url: fetchURL,
     wsClient: graphqlWs.createClient({
       url: subscribeURL,
       shouldRetry: trueLambda,
       lazy: true,
-    })
+    }),
+    headers: headers
   })
-
-  function graphQLFetcher(graphQLParams, opts) {
-    if (typeof opts === 'undefined') {
-      opts = {};
-    }
-    var headers = opts.headers || {};
-    headers['Accept'] = headers['Accept'] || 'application/json';
-    headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-
-    // Parse the cookie value for a CSRF token
-    var csrftoken;
-    var cookies = ("; " + document.cookie).split("; csrftoken=");
-    if (cookies.length == 2) {
-      csrftoken = cookies.pop().split(";").shift();
-    } else {
-      csrftoken = document.querySelector("[name=csrfmiddlewaretoken]").value;
-    }
-    if (csrftoken) {
-      headers['X-CSRFToken'] = csrftoken
-    }
-
-    opts.headers = headers
-
-    return fetcher(graphQLParams, opts)
-  }
 
   // When the query and variables string is edited, update the URL bar so
   // that it can be easily shared.


### PR DESCRIPTION
Fix #1402

After upgrading GraphiQL to v2.4.1 (#1396) all requests seem to fail on Chrome and Safari but works on Firefox. Unfortunately while working on that PR I tested exclusively on Firefox and didn't catch this.

The problem seems to be caused by this line.
https://github.com/graphql-python/graphene-django/blob/34cc86063b4d01212d30c6244ae58cde78b6a139/graphene_django/static/graphene_django/graphiql.js#L78

Also took this opportunity to simplify the GraphQL fetcher logic. `Accept` and `Content-Type` are automatically taken care of and don't need setting explicitly.

A more detailed explanation of the bug: `content-type: application/json` is automatically added and so we have both `content-type` and `Content-Type` in the `headers` object which somehow got turned into `content-type: application/json, application/json` which is invalid.

@sparktx-adam-gleason @dicknetherlands could you help test this with

```sh
pip install git+https://github.com/graphql-python/graphene-django.git@graphiql-headers-fix
```