### PR TITLE
Bump version

### DIFF
--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -1,7 +1,7 @@
 from .fields import DjangoConnectionField, DjangoListField
 from .types import DjangoObjectType
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
This release will address the issue caused by https://github.com/graphql-python/graphene-django/pull/1315

Just a heads up for folks who use get_queryset as an auth layer. If you need that, you can stick with versions between >=3.0.0b9 and <3.1.0 for now. Feel free to suggest a different way that won't lead to those pesky N+1 SQL query issues.