### PR TITLE
Upgrade github actions versions, default python and dev dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Build wheel and source tarball
       run: |
         pip install wheel

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.10
     - name: Build wheel and source tarball

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
         pip install wheel
         python setup.py sdist bdist_wheel
     - name: Publish a Python distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Build wheel and source tarball
       run: |
         pip install wheel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.10
     - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
           - django: "3.2"
             python-version: "3.7"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 default_language_version:
-  python: python3.9
+  python: python3.10
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: check-merge-conflict
     -   id: check-json
@@ -16,15 +16,15 @@ repos:
     -   id: trailing-whitespace
         exclude: README.md
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.0
+    rev: v3.3.2
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
     -   id: flake8

--- a/examples/cookbook-plain/cookbook/ingredients/migrations/0001_initial.py
+++ b/examples/cookbook-plain/cookbook/ingredients/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/examples/cookbook-plain/cookbook/ingredients/migrations/0002_auto_20161104_0050.py
+++ b/examples/cookbook-plain/cookbook/ingredients/migrations/0002_auto_20161104_0050.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("ingredients", "0001_initial"),
     ]

--- a/examples/cookbook-plain/cookbook/ingredients/migrations/0003_auto_20181018_1746.py
+++ b/examples/cookbook-plain/cookbook/ingredients/migrations/0003_auto_20181018_1746.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("ingredients", "0002_auto_20161104_0050"),
     ]

--- a/examples/cookbook-plain/cookbook/recipes/migrations/0001_initial.py
+++ b/examples/cookbook-plain/cookbook/recipes/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/examples/cookbook-plain/cookbook/recipes/migrations/0002_auto_20161104_0106.py
+++ b/examples/cookbook-plain/cookbook/recipes/migrations/0002_auto_20161104_0106.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("recipes", "0001_initial"),
     ]

--- a/examples/cookbook-plain/cookbook/recipes/migrations/0003_auto_20181018_1728.py
+++ b/examples/cookbook-plain/cookbook/recipes/migrations/0003_auto_20181018_1728.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("recipes", "0002_auto_20161104_0106"),
     ]

--- a/examples/cookbook/cookbook/ingredients/migrations/0001_initial.py
+++ b/examples/cookbook/cookbook/ingredients/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/examples/cookbook/cookbook/ingredients/migrations/0002_auto_20161104_0050.py
+++ b/examples/cookbook/cookbook/ingredients/migrations/0002_auto_20161104_0050.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("ingredients", "0001_initial"),
     ]

--- a/examples/cookbook/cookbook/recipes/migrations/0001_initial.py
+++ b/examples/cookbook/cookbook/recipes/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/examples/cookbook/cookbook/recipes/migrations/0002_auto_20161104_0106.py
+++ b/examples/cookbook/cookbook/recipes/migrations/0002_auto_20161104_0106.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("recipes", "0001_initial"),
     ]

--- a/graphene_django/filter/tests/conftest.py
+++ b/graphene_django/filter/tests/conftest.py
@@ -87,7 +87,6 @@ def Query(EventType):
         events = DjangoFilterConnectionField(EventType)
 
         def resolve_events(self, info, **kwargs):
-
             events = [
                 Event(name="Live Show", tags=["concert", "music", "rock"]),
                 Event(name="Musical", tags=["movie", "music"]),

--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -82,7 +82,6 @@ class DjangoFormMutation(BaseDjangoFormMutation):
     def __init_subclass_with_meta__(
         cls, form_class=None, only_fields=(), exclude_fields=(), **options
     ):
-
         if not form_class:
             raise Exception("form_class is required for DjangoFormMutation")
 
@@ -129,7 +128,6 @@ class DjangoModelFormMutation(BaseDjangoFormMutation):
         exclude_fields=(),
         **options,
     ):
-
         if not form_class:
             raise Exception("form_class is required for DjangoModelFormMutation")
 

--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -72,7 +72,6 @@ class SerializerMutation(ClientIDMutation):
         _meta=None,
         **options
     ):
-
         if not serializer_class:
             raise Exception("serializer_class is required for the SerializerMutation")
 

--- a/graphene_django/tests/schema_view.py
+++ b/graphene_django/tests/schema_view.py
@@ -5,7 +5,6 @@ from .mutations import PetFormMutation, PetMutation
 
 
 class QueryRoot(ObjectType):
-
     thrower = graphene.String(required=True)
     request = graphene.String(required=True)
     test = graphene.String(who=graphene.String())

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -780,7 +780,6 @@ def test_should_query_promise_connectionfields():
 
 
 def test_should_query_connectionfields_with_last():
-
     r = Reporter.objects.create(
         first_name="John", last_name="Doe", email="johndoe@example.com", a_choice=1
     )
@@ -818,7 +817,6 @@ def test_should_query_connectionfields_with_last():
 
 
 def test_should_query_connectionfields_with_manager():
-
     r = Reporter.objects.create(
         first_name="John", last_name="Doe", email="johndoe@example.com", a_choice=1
     )

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ tests_require = [
 
 
 dev_requires = [
-    "black==22.8.0",
-    "flake8==5.0.4",
-    "flake8-black==0.3.3",
-    "flake8-bugbear==22.9.11",
+    "black==23.3.0",
+    "flake8==6.0.0",
+    "flake8-black==0.3.6",
+    "flake8-bugbear==23.3.23",
     "pre-commit",
 ] + tests_require
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ rest_framework_require = ["djangorestframework>=3.6.3"]
 
 
 tests_require = [
-    "pytest>=7.1.3",
+    "pytest>=7.3.1",
     "pytest-cov",
     "pytest-random-order",
     "coveralls",


### PR DESCRIPTION
- [x] Use Python 3.10 in deploy.yml
- [x] Use Python 3.10 in lint.yml
- [x] Update setup-python and checkout versions
- [x] Update .pre-commit-config.yaml 
- [x] Match dev dependencies versions with workflows 
- [x] `make format` for examples files and migrations to follow the new black version
- [x] Upgrade pytest version