### PR TITLE
Update docs/requirements.txt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,7 +78,7 @@ release = "1.0.dev"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -445,4 +445,7 @@ epub_exclude_files = ["search.html"]
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {
+    # "https://docs.python.org/": None,
+    "python": ("https://docs.python.org/", None),
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
-Sphinx==1.5.3
-sphinx-autobuild==0.7.1
+Sphinx==7.0.0
+sphinx-autobuild==2021.3.14
+pygments-graphql-lexer==0.1.0
 # Docs template
 http://graphene-python.org/sphinx_graphene_theme.zip

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -224,7 +224,7 @@ Default: ``/graphql``
 
 
 ``GRAPHIQL_SHOULD_PERSIST_HEADERS``
----------------------
+-----------------------------------
 
 Set to ``True`` if you want to persist GraphiQL headers after refreshing the page.
 


### PR DESCRIPTION
Docs building produce errors with old libs, so here is updated reqs and build warning fixes.

* change Sphinx version from 1.5.3 to 7.0.0
* change sphinx-autobuild version from 0.7.1 to 2021.3.14
* add pygments-graphql-lexer to docs/requirements.txt
* fix docs/conf.py (build warnings)
* fix docs/settings.rst

I think this issue can be affected https://github.com/graphql-python/graphene-django/issues/1333 (building stops on error that why docs didn't update on site maybe)