### PR TITLE
Backport Django 4.1 compatibility fixes to v2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
         pip install wheel
         python setup.py sdist bdist_wheel
     - name: Publish a Python distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        django: ["2.2", "3.0", "3.1", "3.2", "4.0"]
+        django: ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1"]
         python-version: ["3.8", "3.9"]
         include:
           - django: "2.2"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,28 +8,22 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        django: ["2.2", "3.0", "3.1", "3.2", "4.0"]
+        django: ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1"]
         python-version: ["3.8", "3.9"]
         include:
           - django: "2.2"
-            python-version: "3.6"
-          - django: "2.2"
             python-version: "3.7"
-          - django: "3.0"
-            python-version: "3.6"
           - django: "3.0"
             python-version: "3.7"
           - django: "3.1"
-            python-version: "3.6"
-          - django: "3.1"
             python-version: "3.7"
-          - django: "3.2"
-            python-version: "3.6"
           - django: "3.2"
             python-version: "3.7"
           - django: "3.2"
             python-version: "3.10"
           - django: "4.0"
+            python-version: "3.10"
+          - django: "4.1"
             python-version: "3.10"
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        django: ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1"]
+        django: ["2.2", "3.0", "3.1", "3.2", "4.0"]
         python-version: ["3.8", "3.9"]
         include:
           - django: "2.2"

--- a/graphene_django/filter/tests/test_array_field_exact_filter.py
+++ b/graphene_django/filter/tests/test_array_field_exact_filter.py
@@ -81,6 +81,7 @@ def test_array_field_exact_empty_list(Query):
     ]
 
 
+@pytest.mark.skipif(ArrayField is MissingType, reason="ArrayField should exist")
 def test_array_field_filter_schema_type(Query):
     """
     Check that the type in the filter is an array field like on the object type.

--- a/graphene_django/forms/tests/test_converter.py
+++ b/graphene_django/forms/tests/test_converter.py
@@ -1,5 +1,5 @@
 from django import forms
-from py.test import raises
+from pytest import raises
 
 from graphene import (
     Boolean,

--- a/graphene_django/forms/tests/test_mutation.py
+++ b/graphene_django/forms/tests/test_mutation.py
@@ -1,7 +1,7 @@
 import pytest
 from django import forms
 from django.core.exceptions import ValidationError
-from py.test import raises
+from pytest import raises
 
 from graphene import Field, ObjectType, Schema, String
 from graphene_django import DjangoObjectType

--- a/graphene_django/management/commands/graphql_schema.py
+++ b/graphene_django/management/commands/graphql_schema.py
@@ -48,7 +48,7 @@ class CommandArguments(BaseCommand):
 class Command(CommandArguments):
     help = "Dump Graphene schema as a JSON or GraphQL file"
     can_import_settings = True
-    requires_system_checks = False
+    requires_system_checks = []
 
     def save_json_file(self, out, schema_dict, indent):
         with open(out, "w") as outfile:

--- a/graphene_django/rest_framework/tests/test_field_converter.py
+++ b/graphene_django/rest_framework/tests/test_field_converter.py
@@ -3,7 +3,7 @@ import copy
 import graphene
 from django.db import models
 from graphene import InputObjectType
-from py.test import raises
+from pytest import raises
 from rest_framework import serializers
 
 from ..serializer_converter import convert_serializer_field

--- a/graphene_django/rest_framework/tests/test_mutation.py
+++ b/graphene_django/rest_framework/tests/test_mutation.py
@@ -1,6 +1,6 @@
 import datetime
 
-from py.test import raises
+from pytest import raises
 from rest_framework import serializers
 
 from graphene import Field, ResolveInfo, NonNull, String

--- a/graphene_django/tests/issues/test_520.py
+++ b/graphene_django/tests/issues/test_520.py
@@ -8,8 +8,8 @@ import graphene
 
 from graphene import Field, ResolveInfo
 from graphene.types.inputobjecttype import InputObjectType
-from py.test import raises
-from py.test import mark
+from pytest import raises
+from pytest import mark
 from rest_framework import serializers
 
 from ...types import DjangoObjectType

--- a/graphene_django/tests/test_command.py
+++ b/graphene_django/tests/test_command.py
@@ -46,7 +46,7 @@ def test_generate_graphql_file_on_call_graphql_schema():
     open_mock.assert_called_once()
 
     handle = open_mock()
-    assert handle.write.called_once()
+    handle.write.assert_called_once()
 
     schema_output = handle.write.call_args[0][0]
     assert schema_output == dedent(

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import pytest
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from py.test import raises
+from pytest import raises
 
 import graphene
 from graphene import NonNull

--- a/graphene_django/tests/test_forms.py
+++ b/graphene_django/tests/test_forms.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from py.test import raises
+from pytest import raises
 
 from ..forms import GlobalIDFormField, GlobalIDMultipleChoiceField
 

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.db.models import Q
 from django.utils.functional import SimpleLazyObject
 from graphql_relay import to_global_id
-from py.test import raises
+from pytest import raises
 
 import graphene
 from graphene.relay import Node

--- a/graphene_django/tests/test_schema.py
+++ b/graphene_django/tests/test_schema.py
@@ -1,4 +1,4 @@
-from py.test import raises
+from pytest import raises
 
 from ..registry import Registry
 from ..types import DjangoObjectType

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ passenv = *
 usedevelop = True
 setenv =
     DJANGO_SETTINGS_MODULE=examples.django_test_settings
+    PYTHONPATH=.
 deps =
     -e.[test]
     psycopg2-binary

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django22,
-    py{36,37,38,39}-django{30,31},
-    py{36,37,38,39,310}-django32,
+    py{37,38,39}-django22,
+    py{37,38,39}-django{30,31},
+    py{37,38,39,310}-django32,
     py{38,39,310}-django{40,master},
     black,flake8
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{37,38,39}-django22,
     py{37,38,39}-django{30,31},
     py{37,38,39,310}-django32,
-    py{38,39,310}-django{40,master},
+    py{38,39,310}-django{40,41,master},
     black,flake8
 
 [gh-actions]
@@ -20,6 +20,7 @@ DJANGO =
     3.1: django31
     3.2: django32
     4.0: django40
+    4.1: django41
     master: djangomaster
 
 [testenv]
@@ -36,6 +37,7 @@ deps =
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1.3,<4.2
     djangomaster: https://github.com/django/django/archive/master.zip
 commands = {posargs:py.test --cov=graphene_django graphene_django examples}
 


### PR DESCRIPTION
This backports https://github.com/graphql-python/graphene-django/pull/1281/commits/e584d5ef5d56cd3f1fdaaca9d8897f04326ed471 to v2 to be used with Django 4.1.

Hoping we can get this to a 2.16 release 🙏 .