### PR TITLE
Set pypi GH action version to release/v1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
         pip install wheel
         python setup.py sdist bdist_wheel
     - name: Publish a Python distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.6
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
So it always uses the latest v1 release. We don't have to manually bump the minor and patch version. That's what the [doc](https://github.com/pypa/gh-action-pypi-publish/blob/unstable/v1/README.md) recommends anyway.