### PR TITLE
Correct schema write test

### DIFF
--- a/graphene_django/tests/test_command.py
+++ b/graphene_django/tests/test_command.py
@@ -46,7 +46,7 @@ def test_generate_graphql_file_on_call_graphql_schema():
     open_mock.assert_called_once()
 
     handle = open_mock()
-    assert handle.write.called_once()
+    handle.write.assert_called_once()
 
     schema_output = handle.write.call_args[0][0]
     assert schema_output == dedent(


### PR DESCRIPTION
Discover this small "typo" while working on #1413.

`<Mock>.called_once()` just returns a `Mock`, so `assert <Mock>.called_once()` always passes. We want `<Mock>.assert_called_once()`.