### PR TITLE
Add check for `serializers.HiddenField` on `fields_for_serializer` function

### DIFF
--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -39,7 +39,9 @@ def fields_for_serializer(
                 field.read_only
                 and is_input
                 and lookup_field != name,  # don't show read_only fields in Input
-                isinstance(field, serializers.HiddenField),  # don't show hidden fields in Input
+                isinstance(
+                    field, serializers.HiddenField
+                ),  # don't show hidden fields in Input
             ]
         )
 

--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -39,6 +39,7 @@ def fields_for_serializer(
                 field.read_only
                 and is_input
                 and lookup_field != name,  # don't show read_only fields in Input
+                isinstance(field, serializers.HiddenField),  # don't show hidden fields in Input
             ]
         )
 

--- a/graphene_django/rest_framework/tests/test_mutation.py
+++ b/graphene_django/rest_framework/tests/test_mutation.py
@@ -164,6 +164,21 @@ def test_read_only_fields():
     ), "'cool_name' is read_only field and shouldn't be on arguments"
 
 
+def test_hidden_fields():
+    class SerializerWithHiddenField(serializers.Serializer):
+        cool_name = serializers.CharField()
+        user = serializers.HiddenField(default=serializers.CurrentUserDefault())
+
+    class MyMutation(SerializerMutation):
+        class Meta:
+            serializer_class = SerializerWithHiddenField
+
+    assert "cool_name" in MyMutation.Input._meta.fields
+    assert (
+        "user" not in MyMutation.Input._meta.fields
+    ), "'user' is hidden field and shouldn't be on arguments"
+
+
 def test_nested_model():
     class MyFakeModelGrapheneType(DjangoObjectType):
         class Meta:


### PR DESCRIPTION
This pull request solves the issue that causes hidden fields to appear in Input when both `SerializerMutation` and serializer class with `HiddenField` are used. This field class is usually used when you want to auto-populate a field, not filled by request's data. So, this field should not be appear in Input.