### PR TITLE
remove JSONFIeld compat

### DIFF
--- a/graphene_django/compat.py
+++ b/graphene_django/compat.py
@@ -10,16 +10,9 @@ try:
         IntegerRangeField,
         ArrayField,
         HStoreField,
-        JSONField as PGJSONField,
         RangeField,
     )
 except ImportError:
-    IntegerRangeField, ArrayField, HStoreField, PGJSONField, RangeField = (
+    IntegerRangeField, ArrayField, HStoreField, RangeField = (
         MissingType,
     ) * 5
-
-try:
-    # JSONField is only available from Django 3.1
-    from django.db.models import JSONField
-except ImportError:
-    JSONField = MissingType

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -35,7 +35,7 @@ except ImportError:
     from graphql import assert_valid_name as assert_name
 from graphql.pyutils import register_description
 
-from .compat import ArrayField, HStoreField, JSONField, PGJSONField, RangeField
+from .compat import ArrayField, HStoreField, RangeField
 from .fields import DjangoListField, DjangoConnectionField
 from .settings import graphene_settings
 from .utils.str_converters import to_const
@@ -346,9 +346,8 @@ def convert_postgres_array_to_list(field, registry=None):
 
 
 @convert_django_field.register(HStoreField)
-@convert_django_field.register(PGJSONField)
-@convert_django_field.register(JSONField)
-def convert_pg_and_json_field_to_string(field, registry=None):
+@convert_django_field.register(models.JSONField)
+def convert_json_field_to_string(field, registry=None):
     return JSONString(
         description=get_django_field_description(field), required=not field.null
     )

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -15,8 +15,6 @@ from graphene.types.scalars import BigInt
 from ..compat import (
     ArrayField,
     HStoreField,
-    JSONField,
-    PGJSONField,
     MissingType,
     RangeField,
 )
@@ -370,16 +368,6 @@ def test_should_postgres_array_multiple_convert_list():
 @pytest.mark.skipif(HStoreField is MissingType, reason="HStoreField should exist")
 def test_should_postgres_hstore_convert_string():
     assert_conversion(HStoreField, JSONString)
-
-
-@pytest.mark.skipif(PGJSONField is MissingType, reason="PGJSONField should exist")
-def test_should_postgres_json_convert_string():
-    assert_conversion(PGJSONField, JSONString)
-
-
-@pytest.mark.skipif(JSONField is MissingType, reason="JSONField should exist")
-def test_should_json_convert_string():
-    assert_conversion(JSONField, JSONString)
 
 
 @pytest.mark.skipif(RangeField is MissingType, reason="RangeField should exist")

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -119,13 +119,12 @@ def test_should_query_postgres_fields():
     from django.contrib.postgres.fields import (
         IntegerRangeField,
         ArrayField,
-        JSONField,
         HStoreField,
     )
 
     class Event(models.Model):
         ages = IntegerRangeField(help_text="The age ranges")
-        data = JSONField(help_text="Data")
+        data = models.JSONField(help_text="Data")
         store = HStoreField()
         tags = ArrayField(models.CharField(max_length=50))
 


### PR DESCRIPTION
Django 3.1 introduced universal JSONFIeld so compatibility is no longer required because we support Django 3.2 or above.