### PR TITLE
Update compat.py MissingType results after PGJSONField removal

### DIFF
--- a/graphene_django/compat.py
+++ b/graphene_django/compat.py
@@ -13,4 +13,4 @@ try:
         RangeField,
     )
 except ImportError:
-    IntegerRangeField, ArrayField, HStoreField, RangeField = (MissingType,) * 5
+    IntegerRangeField, ArrayField, HStoreField, RangeField = (MissingType,) * 4


### PR DESCRIPTION
Since https://github.com/graphql-python/graphene-django/pull/1421/ was merged already (thanks for that cleanup!), figured I'd open a quick fix here separately, as mentioned in https://github.com/graphql-python/graphene-django/pull/1421/files#r1221711648.