### PR TITLE
Add JSONField back to graphene_django.compat module for backwards compatibility

### DIFF
--- a/graphene_django/compat.py
+++ b/graphene_django/compat.py
@@ -1,3 +1,9 @@
+# For backwards compatibility, we import JSONField to have it available for import via
+# this compat module (https://github.com/graphql-python/graphene-django/issues/1428).
+# Django's JSONField is available in Django 3.2+ (the minimum version we support)
+from django.db.models import JSONField
+
+
 class MissingType:
     def __init__(self, *args, **kwargs):
         pass


### PR DESCRIPTION
Fixes https://github.com/graphql-python/graphene-django/issues/1428 (after the change merged in https://github.com/graphql-python/graphene-django/pull/1421)

This should improve backwards compatibility, fixing issues in downstream packages (notably graphene-django-cud
https://github.com/tOgg1/graphene-django-cud/issues/109, and also graphene-django-extras, both of which depended on
`graphene_django.compat.JSONField`). I've tested this in my downstream project and confirmed it resolved issues in both of those packages.