### PR TITLE
Optimize views

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -9,7 +9,14 @@ from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import View
-from graphql import ExecutionResult, OperationType, execute, get_operation_ast, parse
+from graphql import (
+    ExecutionResult,
+    OperationType,
+    execute,
+    get_operation_ast,
+    parse,
+    validate_schema,
+)
 from graphql.error import GraphQLError
 from graphql.execution.middleware import MiddlewareManager
 from graphql.language import OperationDefinitionNode
@@ -295,6 +302,10 @@ class GraphQLView(View):
             if show_graphiql:
                 return None
             raise HttpError(HttpResponseBadRequest("Must provide query string."))
+
+        schema_validation_errors = validate_schema(self.schema.graphql_schema)
+        if schema_validation_errors:
+            return ExecutionResult(data=None, errors=schema_validation_errors)
 
         try:
             document = parse(query)

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -331,8 +331,9 @@ class GraphQLView(View):
             )
 
         execute_args = (self.schema.graphql_schema, document)
+        validation_errors = validate(*execute_args)
 
-        if validation_errors := validate(*execute_args):
+        if validation_errors:
             return ExecutionResult(data=None, errors=validation_errors)
 
         try:

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -12,6 +12,7 @@ from django.views.generic import View
 from graphql import ExecutionResult, OperationType, execute, get_operation_ast, parse
 from graphql.error import GraphQLError
 from graphql.execution.middleware import MiddlewareManager
+from graphql.language import OperationDefinitionNode
 from graphql.validation import validate
 
 from graphene import Schema
@@ -300,13 +301,23 @@ class GraphQLView(View):
 
         operation_ast = get_operation_ast(document, operation_name)
 
-        op_error = None
         if not operation_ast:
-            op_error = "Must provide a valid operation."
-        elif operation_ast.operation == OperationType.SUBSCRIPTION:
-            op_error = "The 'subscription' operation is not supported."
+            ops_count = len(
+                [
+                    x
+                    for x in document.definitions
+                    if isinstance(x, OperationDefinitionNode)
+                ]
+            )
+            if ops_count > 1:
+                op_error = (
+                    "Must provide operation name if query contains multiple operations."
+                )
+            elif operation_name:
+                op_error = f"Unknown operation named '{operation_name}'."
+            else:
+                op_error = "Must provide a valid operation."
 
-        if op_error:
             return ExecutionResult(errors=[GraphQLError(op_error)])
 
         if (
@@ -346,8 +357,7 @@ class GraphQLView(View):
             if (
                 graphene_settings.ATOMIC_MUTATIONS is True
                 or connection.settings_dict.get("ATOMIC_MUTATIONS", False) is True
-                and operation_ast.operation == OperationType.MUTATION
-            ):
+            ) and operation_ast.operation == OperationType.MUTATION:
                 with transaction.atomic():
                     result = execute(*execute_args, **execute_options)
                     if getattr(request, MUTATION_ERRORS_FLAG, False) is True:

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -9,13 +9,12 @@ from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import View
-from graphql import OperationType, get_operation_ast, parse
+from graphql import ExecutionResult, OperationType, execute, get_operation_ast, parse
 from graphql.error import GraphQLError
-from graphql.execution import ExecutionResult
+from graphql.execution.middleware import MiddlewareManager
+from graphql.validation import validate
 
 from graphene import Schema
-from graphql.execution.middleware import MiddlewareManager
-
 from graphene_django.constants import MUTATION_ERRORS_FLAG
 from graphene_django.utils.utils import set_rollback
 
@@ -299,51 +298,63 @@ class GraphQLView(View):
         except Exception as e:
             return ExecutionResult(errors=[e])
 
-        if request.method.lower() == "get":
-            operation_ast = get_operation_ast(document, operation_name)
-            if operation_ast and operation_ast.operation != OperationType.QUERY:
-                if show_graphiql:
-                    return None
+        operation_ast = get_operation_ast(document, operation_name)
 
-                raise HttpError(
-                    HttpResponseNotAllowed(
-                        ["POST"],
-                        "Can only perform a {} operation from a POST request.".format(
-                            operation_ast.operation.value
-                        ),
-                    )
+        op_error = None
+        if not operation_ast:
+            op_error = "Must provide a valid operation."
+        elif operation_ast.operation == OperationType.SUBSCRIPTION:
+            op_error = "The 'subscription' operation is not supported."
+
+        if op_error:
+            return ExecutionResult(errors=[GraphQLError(op_error)])
+
+        if (
+            request.method.lower() == "get"
+            and operation_ast.operation != OperationType.QUERY
+        ):
+            if show_graphiql:
+                return None
+
+            raise HttpError(
+                HttpResponseNotAllowed(
+                    ["POST"],
+                    "Can only perform a {} operation from a POST request.".format(
+                        operation_ast.operation.value
+                    ),
                 )
-        try:
-            extra_options = {}
-            if self.execution_context_class:
-                extra_options["execution_context_class"] = self.execution_context_class
+            )
 
-            options = {
-                "source": query,
+        execute_args = (self.schema.graphql_schema, document)
+
+        if validation_errors := validate(*execute_args):
+            return ExecutionResult(data=None, errors=validation_errors)
+
+        try:
+            execute_options = {
                 "root_value": self.get_root_value(request),
+                "context_value": self.get_context(request),
                 "variable_values": variables,
                 "operation_name": operation_name,
-                "context_value": self.get_context(request),
                 "middleware": self.get_middleware(request),
             }
-            options.update(extra_options)
+            if self.execution_context_class:
+                execute_options[
+                    "execution_context_class"
+                ] = self.execution_context_class
 
-            operation_ast = get_operation_ast(document, operation_name)
             if (
-                operation_ast
+                graphene_settings.ATOMIC_MUTATIONS is True
+                or connection.settings_dict.get("ATOMIC_MUTATIONS", False) is True
                 and operation_ast.operation == OperationType.MUTATION
-                and (
-                    graphene_settings.ATOMIC_MUTATIONS is True
-                    or connection.settings_dict.get("ATOMIC_MUTATIONS", False) is True
-                )
             ):
                 with transaction.atomic():
-                    result = self.schema.execute(**options)
+                    result = execute(*execute_args, **execute_options)
                     if getattr(request, MUTATION_ERRORS_FLAG, False) is True:
                         transaction.set_rollback(True)
                 return result
 
-            return self.schema.execute(**options)
+            return execute(*execute_args, **execute_options)
         except Exception as e:
             return ExecutionResult(errors=[e])
 


### PR DESCRIPTION
This PR is a no-op optimization:
 1. Makes it so that the expensive `parse` call for parsing the request body into valid graphql is not called redundantly
 2. Fails faster if the request does not have a valid `operation_ast`
 3. Removes passing (and handling) the `show_graphiql` kwarg between the view methods