### PR TITLE
Remove Python 3.7 (EOL since EOL since 2023-06-27) from CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,4 +29,3 @@ jobs:
       run: tox
       env:
         DJANGO: ${{ matrix.django }}
-        TOXENV: ${{ matrix.toxenv }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,6 @@ jobs:
         django: ["3.2", "4.1", "4.2"]
         python-version: ["3.8", "3.9", "3.10"]
         include:
-          - django: "3.2"
-            python-version: "3.7"
           - django: "4.1"
             python-version: "3.11"
           - django: "4.2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v3.3.2
     hooks:
     -   id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 -   repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 envlist =
-    py{37,38,39,310}-django32,
+    py{38,39,310}-django32,
     py{38,39,310}-django{41,42,main},
     py311-django{41,42,main}
     pre-commit
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
https://devguide.python.org/versions/