### PR TITLE
Prevent duplicate CI runs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
We have this in our workflows

```yaml
on: [push, pull_request]
```

This is redundant since when someone pushes to a PR branch, it triggers both `push` and `pull_request` `synchronized` which makes the action runs twice. Checking every PR CI and you will see we have the every check run twice `(push)` and `(pull_request)`.

Just `on: push` is enough.