### PR TITLE
fix: foreign key nullable and custom resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ dev-setup:
 
 .PHONY: tests ## Run unit tests
 tests:
-	py.test graphene_django --cov=graphene_django -vv
+	PYTHONPATH=. py.test graphene_django --cov=graphene_django -vv
 
 .PHONY: format ## Format code
 format:

--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -302,12 +302,15 @@ def convert_onetoone_field_to_djangomodel(field, registry=None):
                     reversed_field_name = root.__class__._meta.get_field(
                         field_name
                     ).remote_field.name
-                    return _type.get_queryset(
-                        _type._meta.model.objects.filter(
-                            **{reversed_field_name: root.pk}
-                        ),
-                        info,
-                    ).get()
+                    try:
+                        return _type.get_queryset(
+                            _type._meta.model.objects.filter(
+                                **{reversed_field_name: root.pk}
+                            ),
+                            info,
+                        ).get()
+                    except _type._meta.model.DoesNotExist:
+                        return None
 
                 return custom_resolver
 

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -19,7 +19,11 @@ class Pet(models.Model):
 class FilmDetails(models.Model):
     location = models.CharField(max_length=30)
     film = models.OneToOneField(
-        "Film", on_delete=models.CASCADE, related_name="details"
+        "Film",
+        on_delete=models.CASCADE,
+        related_name="details",
+        null=True,
+        blank=True,
     )
 
 


### PR DESCRIPTION
Fix `model.DoesNotExist` exception when trying to resolve a null one-to-one relationship with a custom `get_queryset` implemented on the `DjangoObjectType` (see test) 