### PR TITLE
Support displaying deprecated input fields in GraphiQL docs

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -197,9 +197,6 @@ Set to ``False`` if you want to disable GraphiQL headers editor tab for some rea
 
 This setting is passed to ``headerEditorEnabled`` GraphiQL options, for details refer to GraphiQLDocs_.
 
-.. _GraphiQLDocs: https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
-
-
 Default: ``True``
 
 .. code:: python
@@ -230,8 +227,6 @@ Set to ``True`` if you want to persist GraphiQL headers after refreshing the pag
 
 This setting is passed to ``shouldPersistHeaders`` GraphiQL options, for details refer to GraphiQLDocs_.
 
-.. _GraphiQLDocs: https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
-
 
 Default: ``False``
 
@@ -240,3 +235,6 @@ Default: ``False``
    GRAPHENE = {
       'GRAPHIQL_SHOULD_PERSIST_HEADERS': False,
    }
+
+
+.. _GraphiQLDocs: https://graphiql-test.netlify.app/typedoc/modules/graphiql_react#graphiqlprovider-2

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -237,4 +237,35 @@ Default: ``False``
    }
 
 
+``GRAPHIQL_INPUT_VALUE_DEPRECATION``
+------------------------------------
+
+Set to ``True`` if you want GraphiQL to show any deprecated fields on input object types' docs.
+
+For example, having this schema:
+
+.. code:: python
+
+    class MyMutationInputType(graphene.InputObjectType):
+        old_field = graphene.String(deprecation_reason="You should now use 'newField' instead.")
+        new_field = graphene.String()
+
+    class MyMutation(graphene.Mutation):
+        class Arguments:
+            input = types.MyMutationInputType()
+
+GraphiQL will add a ``Show Deprecated Fields`` button to toggle information display on ``oldField`` and its deprecation
+reason. Otherwise, you would get neither a button nor any information at all on ``oldField``.
+
+This setting is passed to ``inputValueDeprecation`` GraphiQL options, for details refer to GraphiQLDocs_.
+
+Default: ``False``
+
+.. code:: python
+
+   GRAPHENE = {
+      'GRAPHIQL_INPUT_VALUE_DEPRECATION': False,
+   }
+
+
 .. _GraphiQLDocs: https://graphiql-test.netlify.app/typedoc/modules/graphiql_react#graphiqlprovider-2

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -40,6 +40,7 @@ DEFAULTS = {
     # https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
     "GRAPHIQL_HEADER_EDITOR_ENABLED": True,
     "GRAPHIQL_SHOULD_PERSIST_HEADERS": False,
+    "GRAPHIQL_INPUT_VALUE_DEPRECATION": False,
     "ATOMIC_MUTATIONS": False,
     "TESTING_ENDPOINT": "/graphql",
 }

--- a/graphene_django/static/graphene_django/graphiql.js
+++ b/graphene_django/static/graphene_django/graphiql.js
@@ -122,6 +122,7 @@
       onEditOperationName: onEditOperationName,
       isHeadersEditorEnabled: GRAPHENE_SETTINGS.graphiqlHeaderEditorEnabled,
       shouldPersistHeaders: GRAPHENE_SETTINGS.graphiqlShouldPersistHeaders,
+      inputValueDeprecation: GRAPHENE_SETTINGS.graphiqlInputValueDeprecation,
       query: query,
     };
     if (parameters.variables) {

--- a/graphene_django/templates/graphene/graphiql.html
+++ b/graphene_django/templates/graphene/graphiql.html
@@ -54,6 +54,7 @@ add "&raw" to the end of the URL within a browser.
     {% endif %}
       graphiqlHeaderEditorEnabled: {{ graphiql_header_editor_enabled|yesno:"true,false" }},
       graphiqlShouldPersistHeaders: {{ graphiql_should_persist_headers|yesno:"true,false" }},
+      graphiqlInputValueDeprecation: {{ graphiql_input_value_deprecation|yesno:"true,false" }},
     };
   </script>
   <script src="{% static 'graphene_django/graphiql.js' %}"></script>

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -172,6 +172,7 @@ class GraphQLView(View):
                     # GraphiQL headers tab,
                     graphiql_header_editor_enabled=graphene_settings.GRAPHIQL_HEADER_EDITOR_ENABLED,
                     graphiql_should_persist_headers=graphene_settings.GRAPHIQL_SHOULD_PERSIST_HEADERS,
+                    graphiql_input_value_deprecation=graphene_settings.GRAPHIQL_INPUT_VALUE_DEPRECATION,
                 )
 
             if self.batch:


### PR DESCRIPTION
GraphiQL supports displaying deprecated input fields through an opt-in configuration property.
This PR exposes a new GRAPHENE setting that is forwarded all the way through the aforementioned configuration property.