### PR TITLE
Use ruff format to replace black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.11
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-merge-conflict
     -   id: check-json
@@ -15,12 +15,9 @@ repos:
         - --autofix
     -   id: trailing-whitespace
         exclude: README.md
--   repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-    -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.283
+    rev: v0.1.2
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
+    -   id: ruff-format

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -13,6 +13,7 @@ ignore = [
     "B017",  # pytest.raises(Exception) should be considered evil
     "B028",  # warnings.warn called without an explicit stacklevel keyword argument
     "B904",  # check for raise statements in exception handlers that lack a from clause
+    "W191",  # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 ]
 
 exclude = [
@@ -29,5 +30,4 @@ target-version = "py38"
 [isort]
 known-first-party = ["graphene", "graphene-django"]
 known-local-folder = ["cookbook"]
-force-wrap-aliases = true
 combine-as-imports = true

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ tests:
 
 .PHONY: format ## Format code
 format:
-	black graphene_django examples setup.py
+	ruff format graphene_django examples setup.py
 
 .PHONY: lint ## Lint code
 lint:

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -194,7 +194,7 @@ class DjangoConnectionField(ConnectionField):
         enforce_first_or_last,
         root,
         info,
-        **args
+        **args,
     ):
         first = args.get("first")
         last = args.get("last")

--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -36,7 +36,7 @@ class DjangoFilterConnectionField(DjangoConnectionField):
         extra_filter_meta=None,
         filterset_class=None,
         *args,
-        **kwargs
+        **kwargs,
     ):
         self._fields = fields
         self._provided_filterset_class = filterset_class

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -145,7 +145,7 @@ def replace_csv_filters(filterset_class):
                 label=filter_field.label,
                 method=filter_field.method,
                 exclude=filter_field.exclude,
-                **filter_field.extra
+                **filter_field.extra,
             )
         elif filter_type == "range":
             filterset_class.base_filters[name] = RangeFilter(
@@ -154,5 +154,5 @@ def replace_csv_filters(filterset_class):
                 label=filter_field.label,
                 method=filter_field.method,
                 exclude=filter_field.exclude,
-                **filter_field.extra
+                **filter_field.extra,
             )

--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -23,8 +23,7 @@ def fields_for_form(form, only_fields, exclude_fields):
     for name, field in form.fields.items():
         is_not_in_only = only_fields and name not in only_fields
         is_excluded = (
-            name
-            in exclude_fields  # or
+            name in exclude_fields  # or
             # name in already_created_fields
         )
 

--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -81,7 +81,7 @@ class SerializerMutation(ClientIDMutation):
         convert_choices_to_enum=True,
         _meta=None,
         optional_fields=(),
-        **options
+        **options,
     ):
         if not serializer_class:
             raise Exception("serializer_class is required for the SerializerMutation")

--- a/graphene_django/rest_framework/tests/test_mutation.py
+++ b/graphene_django/rest_framework/tests/test_mutation.py
@@ -275,7 +275,7 @@ def test_perform_mutate_success():
     result = MyMethodMutation.mutate_and_get_payload(
         None,
         mock_info(),
-        **{"cool_name": "Narf", "last_edited": datetime.date(2020, 1, 4)}
+        **{"cool_name": "Narf", "last_edited": datetime.date(2020, 1, 4)},
     )
 
     assert result.errors is None

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -102,10 +102,8 @@ def validate_fields(type_, model, fields, only_fields, exclude_fields):
         if name in all_field_names:
             # Field is a custom field
             warnings.warn(
-                (
-                    'Excluding the custom field "{field_name}" on DjangoObjectType "{type_}" has no effect. '
-                    'Either remove the custom field or remove the field from the "exclude" list.'
-                ).format(field_name=name, type_=type_)
+                f'Excluding the custom field "{name}" on DjangoObjectType "{type_}" has no effect. '
+                'Either remove the custom field or remove the field from the "exclude" list.'
             )
         else:
             if not hasattr(model, name):

--- a/graphene_django/utils/testing.py
+++ b/graphene_django/utils/testing.py
@@ -63,7 +63,7 @@ def graphql_query(
             graphql_url,
             json.dumps(body),
             content_type="application/json",
-            **header_params
+            **header_params,
         )
     else:
         resp = client.post(

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,7 @@ tests_require = [
 
 
 dev_requires = [
-    "black==23.7.0",
-    "ruff==0.0.283",
+    "ruff==0.1.2",
     "pre-commit",
 ] + tests_require
 


### PR DESCRIPTION
Ruff formatter (a black-compatible code formatter built into ruff) is out of beta today https://astral.sh/blog/the-ruff-formatter.
Replace the black pre-commit hook with ruff-format hook for faster formatting.