### PR TITLE
Optimize execute_graphql_request

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -9,7 +9,14 @@ from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import View
-from graphql import ExecutionResult, OperationType, execute, get_operation_ast, parse
+from graphql import (
+    ExecutionResult,
+    OperationType,
+    execute,
+    get_operation_ast,
+    parse,
+    validate_schema,
+)
 from graphql.error import GraphQLError
 from graphql.execution.middleware import MiddlewareManager
 from graphql.language import OperationDefinitionNode
@@ -295,6 +302,10 @@ class GraphQLView(View):
             if show_graphiql:
                 return None
             raise HttpError(HttpResponseBadRequest("Must provide query string."))
+
+        schema_validation_errors = validate_schema(self.schema.graphql_schema)
+        if schema_validation_errors:
+            return ExecutionResult(data=None, errors=schema_validation_errors)
 
         try:
             document = parse(query)

--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -339,8 +339,9 @@ class GraphQLView(View):
             )
 
         execute_args = (self.schema.graphql_schema, document)
+        validation_errors = validate(*execute_args)
 
-        if validation_errors := validate(*execute_args):
+        if validation_errors:
             return ExecutionResult(data=None, errors=validation_errors)
 
         try:


### PR DESCRIPTION
This ported over graphql-core [graphql_impl](https://github.com/graphql-python/graphql-core/blob/0c93b8452eed38d4f800c7e71cf6f3f3758cd1c6/src/graphql/graphql.py#L155) to speed up graphql execution by getting rid of duplicated steps. See https://github.com/graphql-python/graphene-django/pull/1393#issuecomment-1474258711 for context. This also paves the way for implementing support for validations rules (#1342, #1472)

This PR is basically just #1439 with some minor changes
- Added the missing schema validation step in [graphql_impl](https://github.com/graphql-python/graphql-core/blob/0c93b8452eed38d4f800c7e71cf6f3f3758cd1c6/src/graphql/graphql.py#L170)
- Keep the `show_graphiql` arg. Agree with @danthewildcat that this arg is somewhat redundant but removing it is a non-backward compatible change.