### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
             python-version: "3.11"
           - django: "4.2"
             python-version: "3.11"
+          - django: "4.2"
+            python-version: "3.12"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Framework :: Django",
         "Framework :: Django :: 3.2",

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{38,39,310}-django32
     py{38,39}-django{41,42}
     py{310,311}-django{41,42,main}
+    py312-django{42,main}
     pre-commit
 
 [gh-actions]
@@ -11,6 +12,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
Django 4.2.8 which added support for Python 3.12 has just been released.
https://docs.djangoproject.com/en/4.2/faq/install/#what-python-version-can-i-use-with-django

Django 5.0.0 is out as well but Django REST is not fully compatible yet, failing just 1 of our tests. Will settle that in a future PR.