### PR TITLE
feat!: check Django model has a default ordering when used in a Relay Connection

### DIFF
--- a/examples/starwars/models.py
+++ b/examples/starwars/models.py
@@ -24,6 +24,9 @@ class Faction(models.Model):
 
 
 class Ship(models.Model):
+    class Meta:
+        ordering = ["pk"]
+
     name = models.CharField(max_length=50)
     faction = models.ForeignKey(Faction, on_delete=models.CASCADE, related_name="ships")
 

--- a/graphene_django/filter/tests/conftest.py
+++ b/graphene_django/filter/tests/conftest.py
@@ -26,6 +26,9 @@ else:
 
 
 class Event(models.Model):
+    class Meta:
+        ordering = ["pk"]
+
     name = models.CharField(max_length=50)
     tags = ArrayField(models.CharField(max_length=50))
     tag_ids = ArrayField(models.IntegerField())

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -5,6 +5,9 @@ CHOICES = ((1, "this"), (2, _("that")))
 
 
 class Person(models.Model):
+    class Meta:
+        ordering = ["pk"]
+
     name = models.CharField(max_length=30)
     parent = models.ForeignKey(
         "self", on_delete=models.CASCADE, null=True, blank=True, related_name="children"
@@ -12,6 +15,9 @@ class Person(models.Model):
 
 
 class Pet(models.Model):
+    class Meta:
+        ordering = ["pk"]
+
     name = models.CharField(max_length=30)
     age = models.PositiveIntegerField()
     owner = models.ForeignKey(
@@ -31,6 +37,9 @@ class FilmDetails(models.Model):
 
 
 class Film(models.Model):
+    class Meta:
+        ordering = ["pk"]
+
     genre = models.CharField(
         max_length=2,
         help_text="Genre",
@@ -46,6 +55,9 @@ class DoeReporterManager(models.Manager):
 
 
 class Reporter(models.Model):
+    class Meta:
+        ordering = ["pk"]
+
     first_name = models.CharField(max_length=30)
     last_name = models.CharField(max_length=30)
     email = models.EmailField()

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import OrderedDict, defaultdict
 from textwrap import dedent
 from unittest.mock import patch
@@ -399,7 +400,7 @@ def test_django_objecttype_fields_exist_on_model():
     with pytest.warns(
         UserWarning,
         match=r"Field name .* matches an attribute on Django model .* but it's not a model field",
-    ) as record:
+    ):
 
         class Reporter2(DjangoObjectType):
             class Meta:
@@ -407,7 +408,8 @@ def test_django_objecttype_fields_exist_on_model():
                 fields = ["first_name", "some_method", "email"]
 
     # Don't warn if selecting a custom field
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
 
         class Reporter3(DjangoObjectType):
             custom_field = String()
@@ -415,8 +417,6 @@ def test_django_objecttype_fields_exist_on_model():
             class Meta:
                 model = ReporterModel
                 fields = ["first_name", "custom_field", "email"]
-
-    assert len(record) == 0
 
 
 @with_local_registry
@@ -445,14 +445,13 @@ def test_django_objecttype_exclude_fields_exist_on_model():
                 exclude = ["custom_field"]
 
     # Don't warn on exclude fields
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
 
         class Reporter4(DjangoObjectType):
             class Meta:
                 model = ReporterModel
                 exclude = ["email", "first_name"]
-
-    assert len(record) == 0
 
 
 @with_local_registry
@@ -467,23 +466,21 @@ def test_django_objecttype_neither_fields_nor_exclude():
             class Meta:
                 model = ReporterModel
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
 
         class Reporter2(DjangoObjectType):
             class Meta:
                 model = ReporterModel
                 fields = ["email"]
 
-    assert len(record) == 0
-
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
 
         class Reporter3(DjangoObjectType):
             class Meta:
                 model = ReporterModel
                 exclude = ["email"]
-
-    assert len(record) == 0
 
 
 def custom_enum_name(field):


### PR DESCRIPTION
Since predictable ordering is a pre-requisite for a Relay Connection pagination to work, we should enforce it.
Indeed if you don't have a consistent ordering, since the pagination is based on an offset under the hood, when requesting page 2 you wouldn't have guaranteed that it's actually the same order that was used to define page 1.