### PR TITLE
Associate GlobalIDFilter with BigAutoField and SmallAutoField

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -183,17 +183,11 @@ def convert_field_to_string(field, registry=None):
     )
 
 
+@convert_django_field.register(models.SmallAutoField)
 @convert_django_field.register(models.BigAutoField)
 @convert_django_field.register(models.AutoField)
 def convert_field_to_id(field, registry=None):
     return ID(description=get_django_field_description(field), required=not field.null)
-
-
-if hasattr(models, "SmallAutoField"):
-
-    @convert_django_field.register(models.SmallAutoField)
-    def convert_field_small_to_id(field, registry=None):
-        return convert_field_to_id(field, registry)
 
 
 @convert_django_field.register(models.UUIDField)

--- a/graphene_django/filter/filterset.py
+++ b/graphene_django/filter/filterset.py
@@ -11,6 +11,8 @@ from .filters import GlobalIDFilter, GlobalIDMultipleChoiceFilter
 
 GRAPHENE_FILTER_SET_OVERRIDES = {
     models.AutoField: {"filter_class": GlobalIDFilter},
+    models.BigAutoField: {"filter_class": GlobalIDFilter},
+    models.SmallAutoField: {"filter_class": GlobalIDFilter},
     models.OneToOneField: {"filter_class": GlobalIDFilter},
     models.ForeignKey: {"filter_class": GlobalIDFilter},
     models.ManyToManyField: {"filter_class": GlobalIDMultipleChoiceFilter},

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -115,8 +115,7 @@ def test_should_big_auto_convert_id():
 
 
 def test_should_small_auto_convert_id():
-    if hasattr(models, "SmallAutoField"):
-        assert_conversion(models.SmallAutoField, graphene.ID, primary_key=True)
+    assert_conversion(models.SmallAutoField, graphene.ID, primary_key=True)
 
 
 def test_should_uuid_convert_id():


### PR DESCRIPTION
`AutoField` is set up to use `GlobalIDFilter`, but `BigAutoField` and `SmallAutoField` are not.

This MR adds them to `GRAPHENE_FILTER_SET_OVERRIDES`, associating them with the filter.

It also removes some conditional logic around `SmallAutoField` that was introduced in #1212 because [`SmallAutoField` was introduced in Django 3.0](https://docs.djangoproject.com/en/stable/releases/3.0/#models) and this project requires a minimum Django version of 3.2.