### PR TITLE
Allows field's choices to be a callable

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -1,5 +1,6 @@
 import inspect
 from collections import OrderedDict
+from collections.abc import Callable
 from functools import partial, singledispatch, wraps
 
 from django.db import models
@@ -72,6 +73,8 @@ def convert_choice_name(name):
 
 def get_choices(choices):
     converted_names = []
+    if isinstance(choices, Callable):
+        choices = choices()
     if isinstance(choices, OrderedDict):
         choices = choices.items()
     for value, help_text in choices:

--- a/graphene_django/tests/test_converter.py
+++ b/graphene_django/tests/test_converter.py
@@ -180,6 +180,26 @@ def test_field_with_choices_convert_enum():
     assert graphene_type._meta.enum.__members__["EN"].description == "English"
 
 
+def test_field_with_callable_choices_convert_enum():
+    def get_choices():
+        return ("es", "Spanish"), ("en", "English")
+
+    field = models.CharField(help_text="Language", choices=get_choices)
+
+    class TranslatedModel(models.Model):
+        language = field
+
+        class Meta:
+            app_label = "test"
+
+    graphene_type = convert_django_field_with_choices(field).type.of_type
+    assert graphene_type._meta.name == "TestTranslatedModelLanguageChoices"
+    assert graphene_type._meta.enum.__members__["ES"].value == "es"
+    assert graphene_type._meta.enum.__members__["ES"].description == "Spanish"
+    assert graphene_type._meta.enum.__members__["EN"].value == "en"
+    assert graphene_type._meta.enum.__members__["EN"].description == "English"
+
+
 def test_field_with_grouped_choices():
     field = models.CharField(
         help_text="Language",


### PR DESCRIPTION
Starting in Django 5 field's choices can also be a callable https://docs.djangoproject.com/en/5.0/ref/models/fields/#django.db.models.Field.choices