### PR TITLE
fix: Fix broken 'get_choices' with restframework 3.15.0

### DIFF
--- a/graphene_django/converter.py
+++ b/graphene_django/converter.py
@@ -1,5 +1,4 @@
 import inspect
-from collections import OrderedDict
 from functools import partial, singledispatch, wraps
 
 from django.db import models
@@ -72,8 +71,13 @@ def convert_choice_name(name):
 
 def get_choices(choices):
     converted_names = []
-    if isinstance(choices, OrderedDict):
+
+    # In restframework==3.15.0, choices are not passed
+    # as OrderedDict anymore, so it's safer to check
+    # for a dict
+    if isinstance(choices, dict):
         choices = choices.items()
+
     for value, help_text in choices:
         if isinstance(help_text, (tuple, list)):
             yield from get_choices(help_text)


### PR DESCRIPTION
With the latest changes in restframework 3.15.0 ([Release notes](https://www.django-rest-framework.org/community/release-notes/)), it looks like the `get_choices` field in `converter.py` file is broken when provided with integer choices. I looked into it and the cause was that rest-framework is no longer using `OrderedDict`, and instead providing a regular `dict`, which causes the current code to miss the following if statement:

```python
if isinstance(choices, OrderedDict):
        choices = choices.items()
```

Simply switching `OrderedDict` to `dict` should suffice and be retro-compatible, since an `OrderedDict` is ultimately a dictionary. I have tested this change and it works.

