### PR TITLE
Fix ReadTheDocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+      - requirements: docs/requirements.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ make tests
 
 ## Opening Pull Requests
 
-Please fork the project and open a pull request against the master branch.
+Please fork the project and open a pull request against the `main` branch.
 
 This will trigger a series of test and lint checks.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Graphene-Django is an open-source library that provides seamless integration bet
 
 To install Graphene-Django, run the following command:
 
-```
+```sh
 pip install graphene-django
 ```
 
@@ -114,11 +114,11 @@ class MyModelAPITestCase(GraphQLTestCase):
 
 ## Contributing
 
-Contributions to Graphene-Django are always welcome! To get started, check the repository's [issue tracker](https://github.com/graphql-python/graphene-django/issues) and [contribution guidelines](https://github.com/graphql-python/graphene-django/blob/master/CONTRIBUTING.md).
+Contributions to Graphene-Django are always welcome! To get started, check the repository's [issue tracker](https://github.com/graphql-python/graphene-django/issues) and [contribution guidelines](https://github.com/graphql-python/graphene-django/blob/main/CONTRIBUTING.md).
 
 ## License
 
-Graphene-Django is released under the [MIT License](https://github.com/graphql-python/graphene-django/blob/master/LICENSE).
+Graphene-Django is released under the [MIT License](https://github.com/graphql-python/graphene-django/blob/main/LICENSE).
 
 ## Resources
 

--- a/docs/tutorial-plain.rst
+++ b/docs/tutorial-plain.rst
@@ -104,7 +104,7 @@ Load some test data
 
 Now is a good time to load up some test data. The easiest option will be
 to `download the
-ingredients.json <https://raw.githubusercontent.com/graphql-python/graphene-django/master/examples/cookbook/cookbook/ingredients/fixtures/ingredients.json>`__
+ingredients.json <https://raw.githubusercontent.com/graphql-python/graphene-django/main/examples/cookbook/cookbook/ingredients/fixtures/ingredients.json>`__
 fixture and place it in
 ``cookbook/ingredients/fixtures/ingredients.json``. You can then run the
 following:

--- a/docs/tutorial-relay.rst
+++ b/docs/tutorial-relay.rst
@@ -7,7 +7,7 @@ Graphene has a number of additional features that are designed to make
 working with Django *really simple*.
 
 Note: The code in this quickstart is pulled from the `cookbook example
-app <https://github.com/graphql-python/graphene-django/tree/master/examples/cookbook>`__.
+app <https://github.com/graphql-python/graphene-django/tree/main/examples/cookbook>`__.
 
 A good idea is to check the following things first:
 
@@ -87,7 +87,7 @@ Load some test data
 
 Now is a good time to load up some test data. The easiest option will be
 to `download the
-ingredients.json <https://raw.githubusercontent.com/graphql-python/graphene-django/master/examples/cookbook/cookbook/ingredients/fixtures/ingredients.json>`__
+ingredients.json <https://raw.githubusercontent.com/graphql-python/graphene-django/main/examples/cookbook/cookbook/ingredients/fixtures/ingredients.json>`__
 fixture and place it in
 ``cookbook/ingredients/fixtures/ingredients.json``. You can then run the
 following:


### PR DESCRIPTION
Closes #1504

Here we just add the `.readthedocs.yaml` file at the root of the repo.
The basic configuration seems to work out-of-the-box.

I tested this on a fork of the ReadTheDocs build as well, which you can (for now) access here: https://graphene-django-pabloalexis611-fork.readthedocs.io/en/latest/

I will delete the RTD-fork once the PR gets merged.

Also, we may need to make sure that the `graphene-django` RTD project has `main` as it's "latest" branch setup correctly (which I don't have access to).