### PR TITLE
Only catch GraphQLException

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -374,7 +374,7 @@ class GraphQLView(View):
                 return result
 
             return execute(schema, document, **execute_options)
-        except Exception as e:
+        except GraphQLError as e:
             return ExecutionResult(errors=[e])
 
     @classmethod


### PR DESCRIPTION
which allows generic Exception through in case `UnforgivingExecutionContext` is used

replaces #1215, sending from a non-default branch