### PR TITLE
fix typed choices, make working with different Django 5x choices options

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -25,7 +25,6 @@ target-version = "py38"
 [per-file-ignores]
 # Ignore unused imports (F401) in these files
 "__init__.py" = ["F401"]
-"graphene_django/compat.py" = ["F401"]
 
 [isort]
 known-first-party = ["graphene", "graphene-django"]

--- a/graphene_django/compat.py
+++ b/graphene_django/compat.py
@@ -1,10 +1,11 @@
 import sys
+from collections.abc import Callable
 from pathlib import PurePath
 
 # For backwards compatibility, we import JSONField to have it available for import via
 # this compat module (https://github.com/graphql-python/graphene-django/issues/1428).
 # Django's JSONField is available in Django 3.2+ (the minimum version we support)
-from django.db.models import JSONField
+from django.db.models import Choices, JSONField
 
 
 class MissingType:
@@ -42,3 +43,23 @@ except ImportError:
 
     else:
         ArrayField = MissingType
+
+
+try:
+    from django.utils.choices import normalize_choices
+except ImportError:
+
+    def normalize_choices(choices):
+        if isinstance(choices, type) and issubclass(choices, Choices):
+            choices = choices.choices
+
+        if isinstance(choices, Callable):
+            choices = choices()
+
+        # In restframework==3.15.0, choices are not passed
+        # as OrderedDict anymore, so it's safer to check
+        # for a dict
+        if isinstance(choices, dict):
+            choices = choices.items()
+
+        return choices

--- a/graphene_django/forms/types.py
+++ b/graphene_django/forms/types.py
@@ -3,7 +3,7 @@ from graphene import ID
 from graphene.types.inputobjecttype import InputObjectType
 from graphene.utils.str_converters import to_camel_case
 
-from ..converter import BlankValueField
+from ..converter import EnumValueField
 from ..types import ErrorType  # noqa Import ErrorType for backwards compatibility
 from .mutation import fields_for_form
 
@@ -57,11 +57,10 @@ class DjangoFormInputObjectType(InputObjectType):
             if (
                 object_type
                 and name in object_type._meta.fields
-                and isinstance(object_type._meta.fields[name], BlankValueField)
+                and isinstance(object_type._meta.fields[name], EnumValueField)
             ):
-                # Field type BlankValueField here means that field
+                # Field type EnumValueField here means that field
                 # with choices have been converted to enum
-                # (BlankValueField is using only for that task ?)
                 setattr(cls, name, cls.get_enum_cnv_cls_instance(name, object_type))
             elif (
                 object_type

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -1,7 +1,36 @@
+import django
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 CHOICES = ((1, "this"), (2, _("that")))
+
+
+def get_choices_as_class(choices_class):
+    if django.VERSION >= (5, 0):
+        return choices_class
+    else:
+        return choices_class.choices
+
+
+def get_choices_as_callable(choices_class):
+    if django.VERSION >= (5, 0):
+
+        def choices():
+            return choices_class.choices
+
+        return choices
+    else:
+        return choices_class.choices
+
+
+class TypedIntChoice(models.IntegerChoices):
+    CHOICE_THIS = 1
+    CHOICE_THAT = 2
+
+
+class TypedStrChoice(models.TextChoices):
+    CHOICE_THIS = "this"
+    CHOICE_THAT = "that"
 
 
 class Person(models.Model):
@@ -51,6 +80,21 @@ class Reporter(models.Model):
     email = models.EmailField()
     pets = models.ManyToManyField("self")
     a_choice = models.IntegerField(choices=CHOICES, null=True, blank=True)
+    typed_choice = models.IntegerField(
+        choices=TypedIntChoice.choices,
+        null=True,
+        blank=True,
+    )
+    class_choice = models.IntegerField(
+        choices=get_choices_as_class(TypedIntChoice),
+        null=True,
+        blank=True,
+    )
+    callable_choice = models.IntegerField(
+        choices=get_choices_as_callable(TypedStrChoice),
+        null=True,
+        blank=True,
+    )
     objects = models.Manager()
     doe_objects = DoeReporterManager()
     fans = models.ManyToManyField(Person)

--- a/graphene_django/tests/test_schema.py
+++ b/graphene_django/tests/test_schema.py
@@ -40,6 +40,9 @@ def test_should_map_fields_correctly():
         "email",
         "pets",
         "a_choice",
+        "typed_choice",
+        "class_choice",
+        "callable_choice",
         "fans",
         "reporter_type",
     ]

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -77,6 +77,9 @@ def test_django_objecttype_map_correct_fields():
         "email",
         "pets",
         "a_choice",
+        "typed_choice",
+        "class_choice",
+        "callable_choice",
         "fans",
         "reporter_type",
     ]
@@ -186,6 +189,9 @@ def test_schema_representation():
           email: String!
           pets: [Reporter!]!
           aChoice: TestsReporterAChoiceChoices
+          typedChoice: TestsReporterTypedChoiceChoices
+          classChoice: TestsReporterClassChoiceChoices
+          callableChoice: TestsReporterCallableChoiceChoices
           reporterType: TestsReporterReporterTypeChoices
           articles(offset: Int, before: String, after: String, first: Int, last: Int): ArticleConnection!
         }
@@ -197,6 +203,33 @@ def test_schema_representation():
 
           \"""that\"""
           A_2
+        }
+
+        \"""An enumeration.\"""
+        enum TestsReporterTypedChoiceChoices {
+          \"""Choice This\"""
+          A_1
+
+          \"""Choice That\"""
+          A_2
+        }
+
+        \"""An enumeration.\"""
+        enum TestsReporterClassChoiceChoices {
+          \"""Choice This\"""
+          A_1
+
+          \"""Choice That\"""
+          A_2
+        }
+
+        \"""An enumeration.\"""
+        enum TestsReporterCallableChoiceChoices {
+          \"""Choice This\"""
+          THIS
+
+          \"""Choice That\"""
+          THAT
         }
 
         \"""An enumeration.\"""


### PR DESCRIPTION
An attempt to fix #1476

While working on the fix, I realized that Graphene doesn't support choice fields initialized with a types class itself without calling `choices`. Fixed this as well.

Django 5.1 introduced a convenient `normalize_choices` method that I use if a newer django version installed