### PR TITLE
chore: Add support for Django 5.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        django: ["3.2", "4.2", "5.0", "5.1"]
+        django: ["3.2", "4.2", "5.0", "5.1", "5.2"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - django: "3.2"
@@ -26,6 +26,10 @@ jobs:
           - django: "5.1"
             python-version: "3.8"
           - django: "5.1"
+            python-version: "3.9"
+          - django: "5.2"
+            python-version: "3.8"
+          - django: "5.2"
             python-version: "3.9"
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setup(
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.1",
+        "Framework :: Django :: 5.2",
     ],
     keywords="api graphql protocol rest relay graphene",
     packages=find_packages(exclude=["tests", "examples", "examples.*"]),

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ DJANGO =
     4.2: django42
     5.0: django50
     5.1: django51
+    5.2: django52
     main: djangomain
 
 [testenv]
@@ -34,6 +35,7 @@ deps =
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<6.0
     djangomain: https://github.com/django/django/archive/main.zip
 commands = {posargs:pytest --cov=graphene_django graphene_django examples}
 


### PR DESCRIPTION
Hello graphene-django! This pull request introduces a support for Django 5.2, as a follow-up of #1540.

According to the docs, Django 5.2 supports Python 3.10, 3.11. 3.12, and 3.13, so I excluded Python 3.8 and 3.9.

https://docs.djangoproject.com/en/5.2/releases/5.2/#python-compatibility
