### PR TITLE
chore: Replace raw HTTP status codes with `http.HTTPStatus` enums

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import re
+from http import HTTPStatus
 
 from django.db import connection, transaction
 from django.http import HttpResponse, HttpResponseNotAllowed
@@ -195,7 +196,7 @@ class GraphQLView(View):
                 status_code = (
                     responses
                     and max(responses, key=lambda response: response[1])[1]
-                    or 200
+                    or HTTPStatus.OK
                 )
             else:
                 result, status_code = self.get_response(request, data, show_graphiql)
@@ -222,7 +223,7 @@ class GraphQLView(View):
         if getattr(request, MUTATION_ERRORS_FLAG, False) is True:
             set_rollback()
 
-        status_code = 200
+        status_code = HTTPStatus.OK
         if execution_result:
             response = {}
 
@@ -235,7 +236,7 @@ class GraphQLView(View):
             if execution_result.errors and any(
                 not getattr(e, "path", None) for e in execution_result.errors
             ):
-                status_code = 400
+                status_code = HTTPStatus.BAD_REQUEST
             else:
                 response["data"] = execution_result.data
 


### PR DESCRIPTION
Hello graphene-django!

This pull request replaces raw HTTP status codes with their corresponding values from the standard library's [`http.HTTPStatus`](https://docs.python.org/3/library/http.html#http.HTTPStatus) enum — as a follow-up to #1487. This improves readability and aligns with modern Python conventions.

`http.HTTPStatus` has been available since Python 3.5, so this change should remain compatible with all currently supported versions of Python and not affect backporting.

Thanks for your time and review! 🙌
