### PR TITLE
Add notice to README about no active maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # ![Graphene Logo](http://graphene-python.org/favicon.png) Graphene-Django
 
+> [!CAUTION]
+> `graphene-django` no longer has dedicated, active maintenance. If you are looking to use GraphQL with Python and Django, you may want to explore another option like [`strawberry`](https://strawberry.rocks/) with [`strawberry-django`](https://github.com/strawberry-graphql/strawberry-django).
+
+---
+
 [![build][build-image]][build-url]
 [![pypi][pypi-image]][pypi-url]
 [![Anaconda-Server Badge][conda-image]][conda-url]


### PR DESCRIPTION
As discussed on Discord [here](https://discord.com/channels/1069721949065990175/1078319852927856660/1366181622122152016), and as has been noted in a few issues (e.g. https://github.com/graphql-python/graphene-django/pull/1394#issuecomment-2690980263). 

This will ensure expectations are better set for people who come across or are using the project, given that there isn't any ongoing active maintenance currently, and no one is able to shepherd building new functionality, reviewing PRs, handling issue triage, etc.