### PR TITLE
Optional internal Python error masking with whitelist in GraphQL responses

### DIFF
--- a/docs/error-masking.rst
+++ b/docs/error-masking.rst
@@ -1,0 +1,49 @@
+Custom GraphQL Error Masking
+============================
+
+This project includes a custom error formatting function for GraphQL
+responses that masks sensitive error details from clients.
+
+Purpose
+-------
+
+- Prevent exposing internal error details for security and user experience.
+- Allow whitelisting of exception classes that should be exposed as-is.
+- Return a generic error message for all other exceptions.
+
+Configuration
+-------------
+
+You can control the behavior using the ``GRAPHENE_ERRORS`` setting in your
+Django settings file under the ``GRAPHENE`` namespace:
+
+.. code-block:: python
+
+    GRAPHENE = {
+        "GRAPHENE_ERRORS": {
+            "MASK_EXCEPTIONS": True,  # Enable or disable masking
+            "ERROR_MESSAGE": "A custom error message.",  # Defaults to "Something went wrong. Please try again later."
+            "WHITELISTED_EXCEPTIONS": [
+                "ValidationError",  # Whitelist by class name
+                "django.core.exceptions.ValidationError", # Whitelist by full module path
+                "myapp.custom_exceptions.MyCustomException", # Custom exception whitelist by full path
+            ],
+        }
+    }
+
+Behavior
+--------
+
+- If ``MASK_EXCEPTIONS`` is False, all errors are returned fully formatted.
+- If True, errors not in the whitelist will return only the generic message.
+- Whitelisted exceptions are returned with full error details.
+
+Usage
+-----
+
+The masking is automatically applied to the error responses of GraphQL
+queries and mutations through a custom error formatter method.
+
+You can modify or extend the whitelisted exceptions as needed to suit your
+project's error handling policy.
+

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -46,6 +46,7 @@ DEFAULTS = {
     "ATOMIC_MUTATIONS": False,
     "TESTING_ENDPOINT": "/graphql",
     "MAX_VALIDATION_ERRORS": None,
+    "GRAPHENE_ERRORS": {},
 }
 
 if settings.DEBUG:


### PR DESCRIPTION
By default, Graphene returns Django errors (e.g., `ValidationError`) inside the GraphQL `data` object, while `GraphQLErrors` -including internal Python exceptions like `ZeroDivisionError` - are returned outside the `data` field.

For public APIs, exposing full internal error details can be a security risk and a poor user experience. Currently, Graphene lacks built-in support for masking such unhandled internal exceptions.



This PR introduces an opt-in error masking feature that:

 - Masks internal exceptions with a generic error message by default

 - Allows whitelisting of specific exception classes to be returned fully

- Enables configuration via `GRAPHENE_ERRORS` settings, supporting custom messages and whitelisted error classes



This improves API security and usability by preventing leakage of sensitive error information while still exposing known, safe errors.